### PR TITLE
Fix compilation errors and module structure issues

### DIFF
--- a/crates/app/src/stt/tests/mod.rs
+++ b/crates/app/src/stt/tests/mod.rs
@@ -1,15 +1,17 @@
-#[cfg(test)]
+/// STT test utilities and end-to-end tests
+/// 
+/// This module provides utilities for testing speech-to-text functionality,
+/// including WER calculation, timeout handling, and integration tests.
+
+pub mod wer_utils;
+pub mod timeout_utils;
+
+#[cfg(feature = "vosk")]
 pub mod end_to_end_wav;
 
 #[cfg(test)]
-pub mod wer_utils;
-
-#[cfg(test)]
-pub mod timeout_utils;
-
-#[cfg(test)]
 mod vosk_tests {
-    use super::super::*;
+    use crate::stt::*;
 
     #[test]
     fn test_transcription_config_default() {
@@ -82,8 +84,8 @@ mod vosk_tests {
     mod vosk_integration_tests {
         use coldvox_stt::EventBasedTranscriber;
 
-        use super::super::super::vosk::VoskTranscriber;
-        use super::super::super::TranscriptionConfig;
+        use crate::stt::vosk::VoskTranscriber;
+        use crate::stt::TranscriptionConfig;
 
         #[test]
         fn test_vosk_transcriber_missing_model() {
@@ -117,7 +119,7 @@ mod vosk_tests {
                 streaming: false,
             };
 
-            let default_path = super::super::super::vosk::default_model_path();
+            let default_path = crate::stt::vosk::default_model_path();
             let default_exists = std::path::Path::new(&default_path).exists();
 
             let result = VoskTranscriber::new(config, 16000.0);

--- a/crates/app/src/stt/tests/timeout_utils.rs
+++ b/crates/app/src/stt/tests/timeout_utils.rs
@@ -6,8 +6,6 @@ use tokio::time::timeout;
 /// Default timeout for most test operations (30 seconds)
 pub const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Extended timeout for complex operations like STT model loading (60 seconds)
-pub const EXTENDED_TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Wrap an async operation with a timeout and provide clear error messaging.
 pub async fn with_timeout<F, T>(

--- a/crates/app/src/stt/tests/wer_utils.rs
+++ b/crates/app/src/stt/tests/wer_utils.rs
@@ -53,22 +53,6 @@ pub fn format_wer_percentage(wer: f64) -> String {
     format!("{:.1}%", wer * 100.0)
 }
 
-/// Assert that WER is below a given threshold with detailed error message.
-pub fn assert_wer_below_threshold(reference: &str, hypothesis: &str, threshold: f64) {
-    let wer = calculate_wer(reference, hypothesis);
-    
-    if wer > threshold {
-        panic!(
-            "WER {} exceeds threshold {}\n  Reference:  '{}'\n  Hypothesis: '{}'\n  Reference words: {}, Hypothesis words: {}",
-            format_wer_percentage(wer),
-            format_wer_percentage(threshold),
-            reference,
-            hypothesis,
-            reference.split_whitespace().count(),
-            hypothesis.split_whitespace().count()
-        );
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/app/tests/common/test_utils.rs
+++ b/crates/app/tests/common/test_utils.rs
@@ -28,30 +28,3 @@ pub fn feed_samples_to_ring_buffer(
     written_total
 }
 
-/// Calculate Word Error Rate (WER) between reference and hypothesis strings.
-/// Uses word-level Levenshtein distance divided by reference word count.
-/// 
-/// **Note:** This function is deprecated. Use `crate::stt::tests::wer_utils::calculate_wer` instead
-/// for enhanced functionality and consistent return types.
-#[deprecated(since = "0.1.0", note = "Use crate::stt::tests::wer_utils::calculate_wer instead")]
-pub fn calculate_wer(reference: &str, hypothesis: &str) -> f32 {
-    use crate::stt::tests::wer_utils;
-    wer_utils::calculate_wer(reference, hypothesis) as f32
-}
-
-#[cfg(test)]
-mod wer_tests {
-    use super::calculate_wer;
-
-    #[test]
-    fn test_wer_basic() {
-        assert_eq!(calculate_wer("hello world", "hello world"), 0.0);
-        let w = calculate_wer("hello world", "hello there");
-        assert!((w - 0.5).abs() < 1e-6);
-        let w = calculate_wer("one two three", "one three");
-        assert!((w - (1.0 / 3.0)).abs() < 1e-6);
-        let w = calculate_wer("one two", "one two three");
-        assert!((w - 0.5).abs() < 1e-6);
-        assert_eq!(calculate_wer("one two", ""), 1.0);
-    }
-}

--- a/crates/app/tests/common/timeout.rs
+++ b/crates/app/tests/common/timeout.rs
@@ -92,28 +92,6 @@ where
     }
 }
 
-/// Timeout wrapper for audio processing tests
-/// Uses default timeout but adds audio-specific guidance
-pub async fn with_audio_timeout<F, T>(
-    future: F,
-    operation_name: &str,
-) -> Result<T, String>
-where
-    F: std::future::Future<Output = T>,
-{
-    let result = with_timeout(future, Some(DEFAULT_TEST_TIMEOUT), operation_name).await;
-    
-    match result {
-        Err(timeout_msg) => Err(format!(
-            "{}. Audio tests require:\n  \
-            - Audio system availability (ALSA/PulseAudio)\n  \
-            - Proper audio device permissions\n  \
-            - Non-headless environment for full testing",
-            timeout_msg
-        )),
-        Ok(value) => Ok(value),
-    }
-}
 
 /// Test timeout configuration based on environment variables
 /// 
@@ -167,21 +145,21 @@ impl TimeoutConfig {
 #[macro_export]
 macro_rules! timeout_test {
     ($future:expr) => {
-        $crate::tests::common::timeout::with_timeout(
+        $crate::common::timeout::with_timeout(
             $future,
             None,
             stringify!($future)
         )
     };
     ($future:expr, $duration:expr) => {
-        $crate::tests::common::timeout::with_timeout(
+        $crate::common::timeout::with_timeout(
             $future,
             Some($duration),
             stringify!($future)
         )
     };
     ($future:expr, $duration:expr, $name:expr) => {
-        $crate::tests::common::timeout::with_timeout(
+        $crate::common::timeout::with_timeout(
             $future,
             Some($duration),
             $name


### PR DESCRIPTION
## Summary
- Resolves all compilation errors reported in diagnostic output
- Consolidates STT test module structure for better organization
- Removes deprecated and unused code

## Changes Made
- **Removed deprecated `calculate_wer` function** from integration tests that was causing import conflicts
- **Consolidated STT tests**: Moved from `tests.rs` to `tests/mod.rs` structure and properly organized modules
- **Fixed macro path**: Corrected `timeout_test!` macro to use valid crate references
- **Removed unused code**: Eliminated `assert_wer_below_threshold`, `EXTENDED_TEST_TIMEOUT`, and `with_audio_timeout` functions
- **Fixed imports**: Updated import paths in STT test modules to use correct crate references

## Test Plan
- [x] All compilation errors resolved (`cargo check --all-targets` passes)
- [x] No clippy warnings (`cargo clippy -- -D warnings` passes)
- [x] Module structure is properly organized and accessible

🤖 Generated with [Claude Code](https://claude.ai/code)