### PR TITLE
feat: enhance self-hosted runner labels with fedora and nobara specificity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   validate-workflows:
     name: Validate Workflow Definitions
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     continue-on-error: true # Optional validation
     env:
       GH_TOKEN: ${{ github.token }}
@@ -66,7 +66,7 @@ jobs:
 
   download-vosk-model:
     name: Use Vendored Vosk Model
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     outputs:
       model-path: ${{ steps.get-model-path.outputs.path }}
       download-outcome: success
@@ -107,7 +107,7 @@ jobs:
   # Static checks, formatting, linting, type-check, build, and docs
   build_and_check:
     name: Format, Lint, Typecheck, Build & Docs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     needs: [download-vosk-model]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -164,7 +164,7 @@ jobs:
   # MSRV validation
   msrv-check:
     name: MSRV Check (Rust 1.75)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -188,7 +188,7 @@ jobs:
   # GUI groundwork check: explicitly pass if Qt 6 isn't installed
   gui-groundwork:
     name: GUI Groundwork (Qt optional)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -231,7 +231,7 @@ jobs:
 
   text_injection_tests:
     name: Text Injection Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     needs: [download-vosk-model]
     timeout-minutes: 30
     env:
@@ -391,7 +391,7 @@ jobs:
   security:
     name: Security Audit
     if: github.ref == 'refs/heads/main' # Only run on main
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -411,7 +411,7 @@ jobs:
     name: CI Success
     if: always()
     needs: [validate-workflows, download-vosk-model, build_and_check, msrv-check, gui-groundwork, text_injection_tests]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     steps:
       - name: Check if all jobs succeeded
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   release-plz:
     name: Release Please
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
   # Auto-release when the Release PR is merged into main
   release:
     name: Create Release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
       - name: Checkout repository

--- a/.github/workflows/runner-diagnostic.yml
+++ b/.github/workflows/runner-diagnostic.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   diagnose:
     name: Run Diagnostic Checks
-    runs-on: [self-hosted, Linux, X64] # Ensure this matches my runner's labels
+    runs-on: [self-hosted, Linux, X64, fedora, nobara] # Ensure this matches my runner's labels
 
     steps:
       - name: 1. Print Runner Environment Details

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-runner:
     name: Test Self-Hosted Runner
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     timeout-minutes: 5
     
     steps:

--- a/.github/workflows/vosk-integration.yml
+++ b/.github/workflows/vosk-integration.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   vosk-tests:
     name: Vosk STT Integration
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
## Summary

- Enhance GitHub Actions workflow runner labels to include `fedora` and `nobara` for better targeting
- Aligns with Phase 2 of the self-hosted runner migration strategy documented in `docs/tasks/self-hosted-runner-migration-strategy.md`
- Updates all 5 workflow files with consistent enhanced labels `[self-hosted, Linux, X64, fedora, nobara]`

## Changes

### Workflow Files Updated
- **ci.yml**: All 8 job runners (validate-workflows, download-vosk-model, build_and_check, msrv-check, gui-groundwork, text_injection_tests, security, ci-success)
- **release.yml**: Both release-plz and release jobs  
- **runner-test.yml**: Self-hosted runner test job
- **vosk-integration.yml**: Vosk STT integration test job
- **runner-diagnostic.yml**: Runner diagnostic job

### Benefits
- **Better targeting**: Workflows will specifically target the Fedora-based Nobara Linux runner
- **Future-proofing**: Prepares for potential multi-runner scenarios
- **Migration compliance**: Implements Phase 2.1 "Runner Enhancement" from migration strategy
- **Consistency**: All workflows now use identical, specific runner labels

## Test Plan

- [ ] Verify all workflow files have consistent enhanced labels
- [ ] Confirm runner configuration includes matching labels `fedora,nobara`  
- [ ] Test workflow execution with new labels on self-hosted runner
- [ ] Validate no workflow failures due to label mismatch

## Related Documentation

- Migration strategy: `docs/tasks/self-hosted-runner-migration-strategy.md` (Phase 2.1)
- Runner reconfiguration required: `./config.sh --labels self-hosted,Linux,X64,fedora,nobara`

🤖 Generated with [Claude Code](https://claude.ai/code)