### PR TITLE
feat(ci): enable Xvfb for X11 text injection tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,29 +273,34 @@ jobs:
       - name: Setup ColdVox
         uses: ./.github/actions/setup-coldvox
 
-      - name: Start and verify headless environment
+      - name: Start Xvfb
+        uses: GabrielBB/action-xvfb@v1
+        with:
+          run: |
+            set -euo pipefail
+            echo "Installing dependencies..."
+            sudo dnf install -y xclip xdotool at-spi2-core liberation-sans-fonts
+            echo "Xvfb is running."
+
+      - name: Setup D-Bus Session
         run: |
           set -euo pipefail
-          # Use our custom headless environment script
-          DISPLAY=:99 ${{ github.workspace }}/scripts/start-headless.sh
-
-          # Setup D-Bus session
           eval "$(dbus-launch --sh-syntax)"
           echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
           echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID" >> $GITHUB_ENV
-          # Verify D-Bus and clipboard tools
-          if ! pgrep -x "dbus-daemon" >/dev/null; then echo "D-Bus daemon not running" >&2; exit 1; fi
-          echo "D-Bus is running."
-          echo "DBUS_SESSION_BUS_ADDRESS: $DBUS_SESSION_BUS_ADDRESS"
-          echo "DBUS_SESSION_BUS_PID: $DBUS_SESSION_BUS_PID"
-          if ! command -v xclip >/dev/null; then echo "xclip not found"; exit 1; fi
-          if ! command -v wl-paste >/dev/null; then echo "wl-clipboard not found"; exit 1; fi
-          echo "Clipboard utilities are available."
+          echo "D-Bus session started."
 
       - name: Validate test prerequisites
         run: |
+          set -euo pipefail
           echo "=== Test Environment Validation ==="
           echo "Display: $DISPLAY"
+          # Verify that an X server is running
+          if ! xset -q >/dev/null 2>&1; then
+            echo "Error: No X server running on display $DISPLAY"
+            exit 1
+          fi
+          echo "X server is running."
           echo "Available text injection backends:"
           command -v xdotool >/dev/null && echo "  - xdotool: $(xdotool --version 2>/dev/null || echo 'available')"
           command -v ydotool >/dev/null && echo "  - ydotool: available"


### PR DESCRIPTION
### **User description**
Rebased from Jules draft #276. Adds Xvfb virtual display setup in CI for headless X11 text injection testing.

## Changes
- CI workflow updated to install and start Xvfb
- Test harness updated to detect and use virtual display

Closes #276


___

### **PR Type**
Enhancement


___

### **Description**
- Integrate Xvfb virtual display for X11 testing in CI pipeline

- Update test harness to explicitly pass DISPLAY variable

- Replace custom headless script with GabrielBB/action-xvfb GitHub Action

- Simplify D-Bus setup and add X server validation checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["CI Workflow"] -->|"Uses GabrielBB/action-xvfb"| Xvfb["Xvfb Virtual Display"]
  Xvfb -->|"Installs dependencies"| Deps["xclip, xdotool, at-spi2-core"]
  CI -->|"Launches D-Bus session"| DBus["D-Bus Session"]
  TestHarness["Test Harness"] -->|"Reads DISPLAY env var"| Xvfb
  TestHarness -->|"Passes to GTK app"| App["GTK Test Application"]
  Validation["Validation Step"] -->|"Verifies with xset"| Xvfb
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_harness.rs</strong><dd><code>Pass DISPLAY variable to test application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/coldvox-text-injection/src/tests/test_harness.rs

<ul><li>Modified command construction to explicitly pass DISPLAY environment <br>variable to test application<br> <li> Added conditional logic to detect and log DISPLAY variable <br>availability<br> <li> Ensures GTK test app connects to correct X server instance in CI <br>environments</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/310/files#diff-add1b82c5e015188cf8723dad89b7879868c49c4e9f44579b2dc614dd3e7bc49">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Integrate Xvfb action and simplify CI setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replaced custom <code>start-headless.sh</code> script with <code>GabrielBB/action-xvfb</code> <br>GitHub Action<br> <li> Integrated dependency installation (xclip, xdotool, at-spi2-core, <br>liberation-sans-fonts) into Xvfb setup<br> <li> Simplified D-Bus session setup and removed redundant verification <br>checks<br> <li> Added X server validation using <code>xset</code> command in test prerequisites <br>step<br> <li> Improved logging and error handling for headless environment setup</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/310/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+18/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

