### PR TITLE
fix(ci): remove xvfb-action from self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,15 +273,6 @@ jobs:
       - name: Setup ColdVox
         uses: ./.github/actions/setup-coldvox
 
-      - name: Start Xvfb
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: |
-            set -euo pipefail
-            echo "Installing dependencies..."
-            sudo dnf install -y xclip xdotool at-spi2-core liberation-sans-fonts
-            echo "Xvfb is running."
-
       - name: Setup D-Bus Session
         run: |
           set -euo pipefail


### PR DESCRIPTION
### **User description**
## Summary

Removes the `GabrielBB/xvfb-action` from the self-hosted runner job.

## Why

1. **Runner has live KDE Plasma session** - No virtual display needed
2. **xvfb-action uses apt-get internally** - Doesn't exist on Fedora/Nobara
3. **Fixes CI** - Unblocks PR #314 and other pending PRs

## Change

```diff
- - name: Start Xvfb
-   uses: GabrielBB/xvfb-action@v1
-   with:
-     run: |
-       sudo dnf install -y xclip xdotool at-spi2-core liberation-sans-fonts
```

The existing "Validate test prerequisites" step already checks display availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Removes unnecessary xvfb-action from self-hosted runner CI job

- Self-hosted runner has live KDE Plasma display session

- xvfb-action incompatible with Fedora/Nobara (uses apt-get)

- Unblocks pending PRs by fixing CI workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -- "removes" --> B["xvfb-action step"]
  B -- "no longer needed" --> C["Live KDE Plasma session"]
  B -- "incompatible with" --> D["Fedora/Nobara"]
  A -- "unblocks" --> E["Pending PRs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove xvfb-action and dependencies from CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Removes the "Start Xvfb" step that used GabrielBB/xvfb-action@v1<br> <li> Removes dnf package installation for xclip, xdotool, at-spi2-core, and <br>liberation-sans-fonts<br> <li> Simplifies CI workflow by eliminating unnecessary virtual display <br>setup<br> <li> Self-hosted runner already has live KDE Plasma display available</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/319/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

