### PR TITLE
fix(ci): remove hardcoded DISPLAY=:99

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
     needs: [setup-whisper-dependencies]
     timeout-minutes: 30
     env:
-      DISPLAY: :99
+      # DISPLAY inherited from runner's live KDE session (do NOT hardcode :99)
       RUST_LOG: debug
       RUST_TEST_TIME_UNIT: 10000
       RUST_TEST_TIME_INTEGRATION: 30000


### PR DESCRIPTION
### **User description**
## Summary

Removes hardcoded `DISPLAY=:99` from text_injection_tests job. The self-hosted runner has a live KDE Plasma session - display should be inherited from environment.

Follow-up to PR #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove hardcoded DISPLAY=:99 from CI environment variables

- Remove xvfb-action step that's incompatible with Fedora/Nobara

- Use live KDE Plasma session display from self-hosted runner

- Simplify CI workflow by removing unnecessary virtual display setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -->|Remove xvfb-action| B["Eliminate virtual display"]
  A -->|Remove DISPLAY=:99| C["Use live KDE session"]
  B --> D["Simplify self-hosted runner"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove xvfb and hardcoded display configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Removed hardcoded <code>DISPLAY: :99</code> environment variable and replaced with <br>comment explaining display inheritance<br> <li> Removed entire <code>Start Xvfb</code> step that used <code>GabrielBB/xvfb-action@v1</code><br> <li> Removed dependency installation commands for xclip, xdotool, <br>at-spi2-core, and liberation-sans-fonts<br> <li> Kept D-Bus session setup which remains necessary for the self-hosted <br>runner</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/324/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

