### PR TITLE
feat(ci): bifurcate CI into hosted and self-hosted jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,12 +150,63 @@ jobs:
       - name: Build documentation
         run: cargo doc --workspace --no-deps --locked
 
-  # Main build and test job on self-hosted runner
-  build_and_test:
-    name: Build & Test (Self-Hosted)
-    runs-on: [self-hosted, Linux, X64, fedora, nobara]
+  # Build and unit tests on GitHub-hosted (stateless, parallelizable)
+  build_and_unit_tests:
+    name: Build & Unit Tests (Hosted)
+    runs-on: ubuntu-latest
     needs: [setup-whisper-dependencies]
-    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5.0.0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libasound2-dev libgtk-3-dev python3-pip python3-venv
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Type check
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Build
+        run: cargo build --workspace --locked
+
+      - name: Run unit tests
+        env:
+          WHISPER_MODEL_PATH: ${{ needs.setup-whisper-dependencies.outputs.model_path }}
+          WHISPER_MODEL_SIZE: ${{ needs.setup-whisper-dependencies.outputs.model_size }}
+        run: |
+          echo "=== Running Workspace Unit Tests ==="
+          cargo test --workspace --locked
+
+      - name: Run Golden Master pipeline test
+        env:
+          WHISPER_MODEL_PATH: ${{ needs.setup-whisper-dependencies.outputs.model_path }}
+          WHISPER_MODEL_SIZE: ${{ needs.setup-whisper-dependencies.outputs.model_size }}
+        run: |
+          echo "=== Running Golden Master Test ==="
+          pip install faster-whisper
+          export PYTHONPATH=$(python3 -c "import site; print(site.getsitepackages()[0])")
+          cargo test -p coldvox-app --test golden_master -- --nocapture
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-artifacts-build
+          path: |
+            target/debug/deps/
+            target/debug/build/
+          retention-days: 7
+
+  # Hardware tests ONLY - requires live display (self-hosted laptop)
+  hardware_tests:
+    name: Hardware Tests (Self-Hosted)
+    runs-on: [self-hosted, Linux, X64, fedora, nobara]
+    timeout-minutes: 15
     env:
       # Runner's live KDE Wayland session with XWayland
       DISPLAY: ":0"
@@ -163,42 +214,11 @@ jobs:
       RUST_LOG: debug
       RUST_TEST_TIME_UNIT: 10000
       RUST_TEST_TIME_INTEGRATION: 30000
-      SCCACHE_DIR: $HOME/.cache/sccache
-      # Build optimizations
-      CARGO_INCREMENTAL: "1"
-      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      WHISPER_MODEL_PATH: ${{ needs.setup-whisper-dependencies.outputs.model_path }}
-      WHISPER_MODEL_SIZE: ${{ needs.setup-whisper-dependencies.outputs.model_size }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5.0.0
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-
-      # Setup sccache via justfile (installs if missing, enables RUSTC_WRAPPER)
-      - name: Setup sccache
-        run: |
-          # Install just if not available
-          if ! command -v just >/dev/null 2>&1; then
-            cargo install just --locked
-          fi
-
-          # Run setup-sccache recipe (idempotent - installs if missing)
-          just setup-sccache
-
-          # Enable sccache wrapper after installation
-          SCCACHE_BIN=""
-          if command -v sccache >/dev/null 2>&1; then
-            SCCACHE_BIN="$(command -v sccache)"
-          elif [[ -x "$HOME/.cargo/bin/sccache" ]]; then
-            SCCACHE_BIN="$HOME/.cargo/bin/sccache"
-          fi
-
-          if [[ -n "$SCCACHE_BIN" ]]; then
-            "$SCCACHE_BIN" --start-server || true
-            echo "RUSTC_WRAPPER=$SCCACHE_BIN" >> "$GITHUB_ENV"
-            echo "sccache enabled: $SCCACHE_BIN"
-          fi
 
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
@@ -235,75 +255,34 @@ jobs:
             echo "::warning::X11 not accessible via xset"
           fi
 
-      - name: Validate test prerequisites
+      - name: Validate hardware prerequisites
         run: |
           set -euo pipefail
-          echo "=== Test Environment Validation ==="
+          echo "=== Hardware Test Environment Validation ==="
           echo "DISPLAY: $DISPLAY"
           echo "XAUTHORITY: ${XAUTHORITY:-not set}"
           echo "WAYLAND_DISPLAY: ${WAYLAND_DISPLAY:-not set}"
 
-          # Check if XAUTHORITY file exists
-          if [[ -f "${XAUTHORITY:-}" ]]; then
-            echo "XAUTHORITY file exists: $XAUTHORITY"
-          else
-            echo "::warning::XAUTHORITY file not found at ${XAUTHORITY:-unset}"
-          fi
-
           # Verify X server is accessible
           if ! xset -q >/dev/null 2>&1; then
             echo "::error::Cannot connect to X server on display $DISPLAY"
-            echo "Trying xhost diagnostics..."
-            xhost 2>&1 || true
             exit 1
           fi
           echo "X server is accessible."
-          echo "Available text injection backends:"
-          command -v xdotool >/dev/null && echo "  - xdotool: $(xdotool --version 2>/dev/null || echo 'available')"
+          echo "Available backends:"
+          command -v xdotool >/dev/null && echo "  - xdotool: available"
           command -v ydotool >/dev/null && echo "  - ydotool: available"
-          command -v enigo >/dev/null && echo "  - enigo: available (Rust crate)"
-          echo "GTK development libraries:"
-          pkg-config --exists gtk+-3.0 && echo "  - GTK+ 3.0: available" || echo "  - GTK+ 3.0: not found"
-          echo "System audio:"
-          command -v alsa-info >/dev/null && echo "  - ALSA: available" || echo "  - ALSA: not found"
           echo "=== Validation Complete ==="
 
-      - name: Run Workspace Unit Tests
-        run: |
-          echo "=== Running Workspace Unit Tests ==="
-          cargo test --workspace --locked
-
-      - name: Test with real-injection-tests feature
+      - name: Run real injection tests
         run: |
           dbus-run-session -- bash -lc '
-            # Set per-test timeout to prevent hanging
-            export RUST_TEST_TIME_UNIT="10000"  # 10 second timeout per test
-            export RUST_TEST_TIME_INTEGRATION="30000"  # 30 second for integration tests
-            # Note: atspi feature not enabled - AT-SPI Collection.GetMatches requires
-            # a full desktop session, not available in headless Xvfb environment.
-            # AT-SPI tests will skip gracefully.
+            export RUST_TEST_TIME_UNIT="10000"
+            export RUST_TEST_TIME_INTEGRATION="30000"
             cargo test -p coldvox-text-injection \
               --features real-injection-tests \
               -- --nocapture --test-threads=1
           '
-
-      - name: Build pipeline (default features)
-        run: |
-          dbus-run-session -- bash -c '
-            set -euo pipefail
-            echo "Testing default features..."
-            cargo test -p coldvox-text-injection --locked
-
-            echo "Testing without default features..."
-            cargo test -p coldvox-text-injection --no-default-features --locked
-
-            echo "Testing regex feature only..."
-            cargo test -p coldvox-text-injection --no-default-features --features regex --locked
-          '
-
-      # Build main app to ensure integration compiles
-      - name: Build main application
-        run: cargo build --locked -p coldvox-app
 
       - name: Run Hardware Capability Checks
         env:
@@ -311,13 +290,14 @@ jobs:
           COLDVOX_E2E_REAL_AUDIO: "1"
         run: |
           echo "=== Running Hardware Capability Checks ==="
-          # We run the new hardware_check test file, enabling the ignored tests
           cargo test -p coldvox-app --test hardware_check -- --nocapture --include-ignored
 
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
+      - name: Cleanup
+        if: always()
+        run: |
+          if [[ -n "${DBUS_SESSION_BUS_PID:-}" ]]; then
+            kill "$DBUS_SESSION_BUS_PID" 2>/dev/null || true
+          fi
           name: test-artifacts-build-and-test
           path: |
             target/debug/deps/
@@ -379,7 +359,8 @@ jobs:
       - lint
       - security
       - docs
-      - build_and_test
+      - build_and_unit_tests
+      - hardware_tests
       - moonshine_check
     if: always()
     steps:
@@ -392,14 +373,16 @@ jobs:
           echo "- lint:                          ${{ needs.lint.result }}" >> report.md
           echo "- security:                      ${{ needs.security.result }}" >> report.md
           echo "- docs:                          ${{ needs.docs.result }}" >> report.md
-          echo "- build_and_test:                ${{ needs.build_and_test.result }}" >> report.md
+          echo "- build_and_unit_tests:          ${{ needs.build_and_unit_tests.result }}" >> report.md
+          echo "- hardware_tests:                ${{ needs.hardware_tests.result }}" >> report.md
           echo "- moonshine_check:               ${{ needs.moonshine_check.result }} (optional)" >> report.md
           
           if [[ "${{ needs.setup-whisper-dependencies.result }}" != "success" ]]; then echo "::error::Setup Whisper dependencies failed."; exit 1; fi
           if [[ "${{ needs.lint.result }}" != "success" ]]; then echo "::error::Lint checks failed."; exit 1; fi
           if [[ "${{ needs.security.result }}" != "success" ]]; then echo "::warning::Security audit failed - check for vulnerabilities."; fi
           if [[ "${{ needs.docs.result }}" != "success" ]]; then echo "::warning::Documentation build failed."; fi
-          if [[ "${{ needs.build_and_test.result }}" != "success" ]]; then echo "::error::Build and Test failed."; exit 1; fi
+          if [[ "${{ needs.build_and_unit_tests.result }}" != "success" ]]; then echo "::error::Build and Unit Tests failed."; exit 1; fi
+          if [[ "${{ needs.hardware_tests.result }}" != "success" ]]; then echo "::error::Hardware tests failed."; exit 1; fi
           if [[ "${{ needs.moonshine_check.result }}" != "success" ]]; then echo "::warning::Moonshine check failed (optional)."; fi
           
           echo "All critical stages passed successfully."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Default: `silero`, `text-injection`
 
 ## CI Environment
 
-> **Principle**: The self hosted runner on the laptop is used for hardware tests, CI for everything else.
+> **Principle**: The laptop only does what only the laptop can do (hardware tests).
 
 See [CI Architecture](docs/dev/CI/architecture.md) for full details.
 
@@ -163,8 +163,8 @@ See [CI Architecture](docs/dev/CI/architecture.md) for full details.
 |------|-------------|
 | **Live KDE Plasma session** | NO Xvfb needed. Use real `$DISPLAY`. |
 | **Fedora-based** | `apt-get` does NOT exist. Use `dnf`. |
+| **Weak hardware** | Don't run builds or unit tests here. |
 | **Always available** | Auto-login, survives reboots. |
-| **Warm sccache** | Incremental builds ~2-3 min. |
 
 ### CI Split
 
@@ -172,8 +172,8 @@ See [CI Architecture](docs/dev/CI/architecture.md) for full details.
 |------|--------|-----|
 | `cargo fmt`, `cargo clippy` | GitHub-hosted | Fast, parallel, free |
 | `cargo audit`, `cargo deny` | GitHub-hosted | Security checks, no build needed |
-| `cargo build` | **Self-hosted** | Warm cache, THE build |
-| Hardware tests | **Self-hosted** | Requires display/audio/clipboard |
+| `cargo build`, `cargo test` | GitHub-hosted | Powerful hardware, parallelizable |
+| Hardware tests (display/audio/clipboard) | **Self-hosted** | Requires live desktop session |
 
 ### DON'T (Common AI Mistakes)
 
@@ -188,12 +188,9 @@ See [CI Architecture](docs/dev/CI/architecture.md) for full details.
 env:
   DISPLAY: ":99"
 
-# WRONG - delays self-hosted by 5-10 min
-hardware:
-  needs: [lint, build]
-
-# WRONG - wasted work, can't share artifacts with Fedora
-- run: cargo build  # On ubuntu-latest
+# WRONG - overloads weak laptop with work GitHub can do
+- run: cargo build  # On self-hosted
+- run: cargo test --workspace  # On self-hosted
 ```
 
 ## PR Checklist


### PR DESCRIPTION
### **User description**
Implements the CI bifurcation plan described in Proposal B and Issue #329.

### Changes
- **Split `unit_tests_hosted`**: Replaced the monolithic job with parallel `lint`, `security`, and `docs` jobs running on `ubuntu-latest`.
- **Renamed `text_injection_tests` to `build_and_test`**: This job now runs on the self-hosted runner and handles:
    - Workspace build (leveraging warm cache).
    - Workspace unit tests (`cargo test --workspace`).
    - Hardware integration tests (with `real-injection-tests` feature).
- **Updated `ci_success`**: Now depends on the new parallel jobs.

### Benefits
- **Faster Feedback**: Lint, security, and docs run in parallel on GitHub infrastructure.
- **Better Resource Usage**: The self-hosted runner focuses on building and hardware tests, reducing contention.
- **Cleaner Architecture**: Explicit separation of concerns between stateless checks and stateful/hardware-dependent tests.

Closes #329


___

### **PR Type**
Enhancement


___

### **Description**
- Split monolithic `unit_tests_hosted` into three parallel jobs: `lint`, `security`, and `docs`

- Renamed `text_injection_tests` to `build_and_test` with expanded responsibilities

- Moved build, workspace tests, and hardware integration tests to self-hosted runner

- Updated `ci_success` job to depend on new parallel jobs with refined error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["unit_tests_hosted<br/>monolithic job"] -->|split| B["lint<br/>fmt + clippy"]
  A -->|split| C["security<br/>audit + deny"]
  A -->|split| D["docs<br/>documentation"]
  E["text_injection_tests"] -->|renamed| F["build_and_test<br/>self-hosted"]
  B --> G["ci_success"]
  C --> G
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Restructure CI workflow into parallel and self-hosted jobs</code></dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Renamed <code>security_audit</code> job to <code>security</code> for consistency<br> <li> Split <code>unit_tests_hosted</code> into three independent parallel jobs: <code>lint</code> <br>(fmt + clippy), <code>security</code> (audit + deny), and <code>docs</code> (documentation <br>build)<br> <li> Renamed <code>text_injection_tests</code> to <code>build_and_test</code> and added workspace <br>unit tests execution<br> <li> Added <code>WHISPER_MODEL_PATH</code> and <code>WHISPER_MODEL_SIZE</code> environment variables <br>to <code>build_and_test</code> job<br> <li> Updated <code>ci_success</code> job dependencies and CI report generation to <br>reference new job names with refined error handling logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/330/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+40/-100</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

