### PR TITLE
fix: restore agent mirror flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@
 
 Minimal root README. Full developer & architecture guide: see [`CLAUDE.md`](CLAUDE.md). Assistants should read [`AGENTS.md`](AGENTS.md).
 
+## Quick Start
+
+Status varies by STT backend and platform. For current “what works” details, see [`docs/plans/critical-action-plan.md`](docs/plans/critical-action-plan.md).
+
+```bash
+# Main app
+just run
+
+# TUI dashboard
+just tui
+```
+
+Common Rust commands:
+
+```bash
+# Fast local feedback
+cargo check -p coldvox-app
+
+# Format check
+cargo fmt --all -- --check
+```
+
 ## Development
 
 ### Developer Git Hooks

--- a/docs/MasterDocumentationPlaybook.md
+++ b/docs/MasterDocumentationPlaybook.md
@@ -93,13 +93,13 @@ The following files configure AI coding agents and MUST live at standard locatio
 
 - `AGENTS.md` (root): Canonical agent instructions following the [AGENTS.md standard](https://agents.md/). This is the single source of truth for all AI agents.
 - `CLAUDE.md` (root): Claude Code configuration. Should import from or reference `AGENTS.md`.
-- `.github/copilot-instructions.md`: GitHub Copilot instructions. Must match `AGENTS.md` (locally hardlinked where possible).
-- `.kilocode/rules/agents.md`: Kilo Code rules. Must match `AGENTS.md` (locally hardlinked where possible).
+- `.github/copilot-instructions.md`: GitHub Copilot instructions. Must match `AGENTS.md` (hardlink preferred; symlink/copy acceptable where needed).
+- `.kilocode/rules/agents.md`: Kilo Code rules. Must match `AGENTS.md` (hardlink preferred; symlink/copy acceptable where needed).
 - `.gemini/settings.json`: Gemini CLI configuration. Set `"contextFileName": "AGENTS.md"` to use root AGENTS.md.
 - `.cursorrules` (root, optional): Cursor-specific rules if needed beyond `AGENTS.md`.
 - `.builderrules` (root, optional): Builder.io-specific rules if needed.
 
-**Hierarchy**: `AGENTS.md` is authoritative. Tool-specific files should either be hardlinked mirrors (preferred) or contain only tool-specific overrides that reference `AGENTS.md`.
+**Hierarchy**: `AGENTS.md` is authoritative. Tool-specific files should either mirror it (hardlink preferred; symlink/copy acceptable) or contain only tool-specific overrides that reference `AGENTS.md`.
 
 **Do NOT create** `docs/agents.md` - agent configuration lives at the root for tool discovery.
 

--- a/docs/dev/CI/architecture.md
+++ b/docs/dev/CI/architecture.md
@@ -210,7 +210,7 @@ jobs:
       - run: cargo deny check
 
   # ═══════════════════════════════════════════════════════════════
-  # SELF-HOSTED: THE build, THE tests (runs immediately, no waiting)
+  # SELF-HOSTED: Hardware/display-only tests (runs immediately, no waiting)
   # ═══════════════════════════════════════════════════════════════
 
   hardware:
@@ -234,9 +234,6 @@ jobs:
         with:
           shared-key: "nobara-hardware"
           cache-on-failure: true
-
-      - name: Build (cached, incremental)
-        run: cargo build -p coldvox-text-injection -p coldvox-app --locked
 
       - name: Validate display environment
         run: |

--- a/scripts/install_git_hardlink_hooks.sh
+++ b/scripts/install_git_hardlink_hooks.sh
@@ -2,9 +2,19 @@
 set -euo pipefail
 
 quiet=0
-if [[ "${1:-}" == "--quiet" ]]; then
-  quiet=1
-fi
+require_hardlink=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --quiet) quiet=1 ;;
+    --require-hardlink) require_hardlink=1 ;;
+    *)
+      echo "error: unknown arg: $arg" >&2
+      echo "usage: $0 [--quiet] [--require-hardlink]" >&2
+      exit 64
+      ;;
+  esac
+done
 
 repo_root="$({
   cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
@@ -35,4 +45,8 @@ if [[ "$quiet" -eq 0 ]]; then
   fi
 fi
 
-"$repo_root/scripts/ensure_agent_hardlinks.sh" ${quiet:+--quiet}
+ensure_args=()
+if [[ "$quiet" -eq 1 ]]; then ensure_args+=(--quiet); fi
+if [[ "$require_hardlink" -eq 1 ]]; then ensure_args+=(--require-hardlink); fi
+
+"$repo_root/scripts/ensure_agent_hardlinks.sh" "${ensure_args[@]}"


### PR DESCRIPTION
### **User description**
Implements (instead of redacting) a resilient agent-instruction mirror strategy and restores a usable Quick Start.

- Agent mirrors: best-effort hardlink -> symlink -> copy; default succeeds as long as contents match; optional --require-hardlink enforces strict mode.
- CI architecture doc: removes outdated 'self-hosted is THE build' snippet; keeps self-hosted hardware/display-only.
- README: restores quick start commands while keeping critical action plan as source of truth for current backend status.
- MasterDocumentationPlaybook: documents hardlink preferred but symlink/copy acceptable where needed.

Commands:
- Best-effort: ./scripts/ensure_agent_hardlinks.sh
- Strict: ./scripts/ensure_agent_hardlinks.sh --require-hardlink


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implements resilient three-tier agent mirror strategy: hardlink → symlink → copy

- Adds `--require-hardlink` flag for strict mode; default allows symlink/copy fallbacks

- Restores Quick Start section to README with current backend status reference

- Updates documentation to reflect flexible mirroring approach across tools

- Removes outdated CI architecture claim about self-hosted being "THE build"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent Mirror Request"] --> B{"Hardlink\nPossible?"}
  B -->|Yes| C["Create Hardlink"]
  B -->|No| D{"Symlink\nPossible?"}
  D -->|Yes| E["Create Symlink"]
  D -->|No| F["Copy Contents"]
  C --> G{"--require-hardlink\nSet?"}
  E --> G
  F --> G
  G -->|Yes| H{"Hardlinked?"}
  G -->|No| I["Success with Warning"]
  H -->|Yes| I
  H -->|No| J["Exit with Error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ensure_agent_hardlinks.sh</strong><dd><code>Add symlink fallback and strict mode flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/ensure_agent_hardlinks.sh

<ul><li>Implements three-tier fallback strategy: hardlink → symlink → copy<br> <li> Adds <code>--require-hardlink</code> flag to enforce strict hardlink-only mode<br> <li> Renames function from <code>link_or_copy</code> to <code>link_or_symlink_or_copy</code> for <br>clarity<br> <li> Makes hardlink requirement conditional; defaults to best-effort with <br>warnings<br> <li> Improves argument parsing with case statement supporting multiple <br>flags</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/337/files#diff-fad31da8d8375ff075fc54ee0c7f2688a6c2904c78be8a45211484c69e6d419e">+43/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install_git_hardlink_hooks.sh</strong><dd><code>Support require-hardlink flag propagation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/install_git_hardlink_hooks.sh

<ul><li>Updates argument parsing to support both <code>--quiet</code> and <br><code>--require-hardlink</code> flags<br> <li> Propagates <code>--require-hardlink</code> flag to <code>ensure_agent_hardlinks.sh</code> call<br> <li> Uses array-based argument passing for cleaner flag forwarding</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/337/files#diff-c31bc46e0a822734772bc2bbbee3569eb590f3060a8f3275f71320d56d8e4464">+18/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Restore Quick Start section with commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds Quick Start section with basic commands for running app and TUI<br> <li> References critical-action-plan.md for current backend status details<br> <li> Includes common Rust development commands (check, fmt)<br> <li> Restores usable quick reference while keeping action plan as source of <br>truth</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/337/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MasterDocumentationPlaybook.md</strong><dd><code>Document flexible agent mirroring strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/MasterDocumentationPlaybook.md

<ul><li>Updates agent mirror documentation to reflect flexible approach<br> <li> Changes language from "hardlinked where possible" to "hardlink <br>preferred; symlink/copy acceptable"<br> <li> Updates hierarchy description to acknowledge multiple mirroring <br>strategies<br> <li> Clarifies that tool-specific files can use hardlink, symlink, or copy</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/337/files#diff-96e6618f10b913478f0a05ac18b77d83a2beeccd9b781bc1e4f069d6a8946b8a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>architecture.md</strong><dd><code>Remove outdated self-hosted CI architecture claim</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/dev/CI/architecture.md

<ul><li>Removes outdated claim that self-hosted is "THE build, THE tests"<br> <li> Reframes self-hosted job as "Hardware/display-only tests"<br> <li> Removes redundant cargo build step from hardware job<br> <li> Clarifies actual purpose of self-hosted CI infrastructure</ul>


</details>


  </td>
  <td><a href="https://github.com/Coldaine/ColdVox/pull/337/files#diff-edd2827a7caa42f039a39ae6bdaebf79620170ab900ba15e7738ff47826b9c4b">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

