### PR TITLE
fix: add missing description field to coldvox-app Cargo.toml

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "coldvox-app"
 version = "0.1.0"
 edition = "2021"
+description = "ColdVox voice dictation application"
 publish = false
 autotests = false
 


### PR DESCRIPTION
Adds the missing `description` metadata field to `crates/app/Cargo.toml`. Every other crate in the workspace already has one; this was the lone omission.

No behaviour change — pure metadata. `publish = false` means this doesn't affect crates.io.

---
🤖 Stack 2 smoke-test PR — exercising the automerge pipeline end-to-end.

Generated with [Claude Code](https://claude.ai/claude-code) · codex/kimi reviewed