### PR TITLE
ci: harden gate-main source-branch check with fork protection

### DIFF
--- a/.github/workflows/gate-main.yml
+++ b/.github/workflows/gate-main.yml
@@ -1,17 +1,61 @@
 name: Gate main branch
 
+# This workflow enforces that PRs to main can only originate from tauri-base.
+# It is configured as a required status check on the main branch.
+#
+# Security model:
+#   - github.head_ref: the source branch name (can be spoofed by fork users
+#     who name their branch 'tauri-base')
+#   - github.event.pull_request.head.repo.full_name: the source repo (catches
+#     fork PRs from any user, even those naming their branch 'tauri-base')
+#   - Both checks are required: branch must be named 'tauri-base' AND must
+#     come from the canonical Coldaine/ColdVox repo (not a fork).
+#
+# Limitation: Direct pushes to main bypass this workflow entirely.
+# Branch protection's "Restrict who can push" handles that case.
+
 on:
   pull_request:
     branches: [main]
 
 jobs:
   check-source-branch:
+    name: check-source-branch
     runs-on: ubuntu-latest
     steps:
-      - name: Verify PR comes from tauri-base
-        if: github.head_ref != 'tauri-base'
+      - name: Verify PR comes from tauri-base on canonical repo
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          echo "::error::PRs to main must come from tauri-base, not '$HEAD_REF'"
-          exit 1
+          echo "PR source branch : $HEAD_REF"
+          echo "PR source repo   : $HEAD_REPO"
+          echo "Target repo      : $BASE_REPO"
+          echo ""
+
+          FAILED=0
+
+          # Check 1: branch name must be tauri-base
+          if [ "$HEAD_REF" != "tauri-base" ]; then
+            echo "::error::Branch check FAILED — source branch is '$HEAD_REF', expected 'tauri-base'."
+            echo "::error::Only the tauri-base branch may merge into main."
+            FAILED=1
+          fi
+
+          # Check 2: PR must come from the canonical repo (not a fork)
+          # This prevents fork users from bypassing the gate by naming their
+          # branch 'tauri-base'.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Fork check FAILED — PR is from fork '$HEAD_REPO', not '$BASE_REPO'."
+            echo "::error::Fork PRs are not permitted to merge directly into main."
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "::error::Gate FAILED. PRs to main must come from the tauri-base branch of $BASE_REPO."
+            exit 1
+          fi
+
+          echo "Gate PASSED — source branch is 'tauri-base' from canonical repo '$HEAD_REPO'."


### PR DESCRIPTION
Hardens `.github/workflows/gate-main.yml` (introduced in the automerge pipeline PR) to close a fork-bypass hole.

## What changed

**Previous state** (draft from `setup-automerge-pipeline`): only checked `github.head_ref == 'tauri-base'` — a fork user who names their branch `tauri-base` would pass.

**Now**: two-check gate:
1. Branch name must be `tauri-base`
2. Source repo must be `Coldaine/ColdVox` (not a fork)

This closes the fork-spoofing vector. Direct pushes to `main` are handled separately by branch protection.

## After this merges

Run the following to add `check-source-branch` as a required status check on `main`:

```bash
gh api repos/Coldaine/ColdVox/branches/main/protection \
  --method PUT \
  --header "Accept: application/vnd.github+json" \
  --input - <<'APIEOF'
{
  "required_status_checks": {
    "strict": false,
    "contexts": ["check-source-branch"]
  },
  "enforce_admins": true,
  "required_pull_request_reviews": {
    "dismiss_stale_reviews": true,
    "require_code_owner_reviews": false,
    "require_last_push_approval": false,
    "required_approving_review_count": 1
  },
  "restrictions": null,
  "required_linear_history": false,
  "allow_force_pushes": false,
  "allow_deletions": false,
  "block_creations": false,
  "required_conversation_resolution": false
}
APIEOF
```
> ⚠️ Run this **after** the first PR targeting `main` has triggered the workflow (so GitHub registers the check name).

---
🤖 Stack 3 — codex/kimi red-teamed (PASS on all 5 threat vectors).

Generated with [Claude Code](https://claude.ai/claude-code)