### PR TITLE
docs: align Windows validation runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,110 +1,57 @@
 # AGENTS.md
 
-Canonical AI agent instructions for ColdVox. This file is the source of truth for all agent tools.
+Canonical AI agent instructions for ColdVox.
 
-## Anchor
+## Repo Truth
 
-- Product and technical anchor: `docs/northstar.md`
-- Current execution state: `docs/plans/current-status.md`
-- Architecture direction: `docs/architecture.md`
-- CI source of truth: `docs/dev/CI/architecture.md`
+- Windows 11 is the priority environment.
+- The checked-in startup config is intentionally test-friendly: `config/default.toml` defaults to `mock`.
+- The supported Windows live path for this wave is `COLDVOX_CONFIG_PATH=config/windows-parakeet.toml` plus `PARAKEET_MODEL_PATH` on NVIDIA/CUDA hardware.
+- `config/plugins.json` is plugin-manager persistence, not the operator-facing startup source of truth.
+- The Windows GUI is out of scope for this wave. `coldvox-gui` is a stub smoke target only.
+- CI is not the authoritative gate for this wave. Local Windows validation is.
 
-If guidance conflicts, use this precedence:
-1. `docs/northstar.md`
-2. `docs/plans/current-status.md`
-3. `docs/dev/CI/architecture.md`
+## Recent Branch Reality
 
-## Current Product Direction & Reality
-
-- **Target OS:** Windows 11 priority.
-- **Python Environment:** Exclusively managed by `uv`. Do NOT use `mise` or raw `pip` for Python packages. Ensure `.python-version` is respected.
-- **STT Backend:**
-  - **Moonshine:** The current working backend, but considered a fragile dependency due to PyO3.
-  - **Parakeet:** The designated successor for a pure-Rust/Windows-native STT pipeline (CUDA/DirectML). It *does* compile; focus on runtime validation.
-  - **Vaporware:** The `whisper`, `coqui`, `leopard`, and `silero-stt` feature flags are dead stubs. Do not attempt to use them.
-
-## Project Overview
-
-ColdVox is a Rust voice pipeline: audio capture -> VAD -> STT -> text injection.
-Multi-crate Cargo workspace under `crates/`.
-
-Key crates to know:
-- `coldvox-app` (Main execution and binaries)
-- `coldvox-audio` (Capture and resampling via rubato)
-- `coldvox-stt` (STT Plugin logic)
-- `coldvox-text-injection` (Output injection logic)
-
-## Working Rules
-
-**DO:**
-- Use `cargo {cmd} -p {crate}` for iteration speed, but finish with `cargo check --workspace --all-targets`.
-- Only use live testing (real microphone/`.wav` files) to test VAD and STT. Do not mock audio buffers.
-- Check `docs/plans/current-status.md` for what currently works and what's broken.
-
-**DO NOT:**
-- Claim Whisper or Parakeet are currently production-ready.
-- Modify Python dependencies without using `uv`.
-- Auto-run commands that destroy data or commit unverified changes.
+- `main` contains the current trunk we should build on.
+- The old Qt remediation line from closed PR `#389` is not a valid base for new work.
+- Start fresh branches from `origin/main` or from the current stacked branch tip, never from the old remediation line.
 
 ## Commands
 
-File-scoped (preferred):
-```bash
+Crate-scoped commands are still preferred for iteration:
+
+```powershell
 cargo check -p coldvox-stt
-cargo clippy -p coldvox-audio
-cargo test -p coldvox-text-injection
+cargo test -p coldvox-foundation --lib --locked
+cargo test -p coldvox-app --test golden_master --locked
 cargo fmt --all -- --check
 ```
 
-Workspace (when needed):
-```bash
-./scripts/local_ci.sh
-cargo clippy --workspace --all-targets --locked
-cargo test --workspace --locked
-cargo build --workspace --locked
+Windows local validation:
+
+```powershell
+just windows-run-preflight
+just windows-smoke
+just test
 ```
 
-Run:
-```bash
-cargo run -p coldvox-app --bin coldvox
-cargo run -p coldvox-app --bin tui_dashboard
-cargo run --features text-injection,moonshine
+Optional live validation during the Windows test gate:
+
+```powershell
+$env:COLDVOX_RUN_WINDOWS_LIVE = '1'
+just test
 ```
 
-## Feature Flags
+Direct live validation:
 
-- `silero`: Silero VAD
-- `text-injection`: text injection backends
-- `moonshine`: Current working STT backend (Python-based, CPU/GPU)
-- `parakeet`: planned backend work; not current reliable path
-- `examples`: example binaries
-- `live-hardware-tests`: hardware test suites
+```powershell
+just windows-live
+```
 
-## CI Environment
+## Working Rules
 
-Canonical CI policy is `docs/dev/CI/architecture.md`.
-
-Principle:
-- GitHub-hosted runners handle fast general CI work.
-- Self-hosted Fedora/Nobara runner handles hardware-dependent tests.
-
-Do not use:
-- Xvfb on self-hosted runner
-- `apt-get` on Fedora runner
-- `DISPLAY=:99` in self-hosted jobs
-
-## Key Files
-
-- Main entry: `crates/app/src/main.rs`
-- Audio capture: `crates/coldvox-audio/src/capture.rs`
-- VAD engine: `crates/coldvox-vad-silero/src/silero_wrapper.rs`
-- STT plugins: `crates/coldvox-stt/src/plugins/`
-- Text injection manager: `crates/coldvox-text-injection/src/manager.rs`
-- Build detection: `crates/app/build.rs`
-
-## PR Checklist
-
-- `./scripts/local_ci.sh` passes (or equivalent crate-scoped checks)
-- Docs updated for behavior/direction changes
-- `CHANGELOG.md` updated for user-visible changes
-- No secrets committed
+- Prefer the local Windows gate over CI status for this wave.
+- Keep the default path deterministic for tests; do not flip the checked-in default away from `mock`.
+- Only claim the Windows live path is validated when you have local artifacts under `logs/windows-validation/`.
+- Do not describe the GUI as Windows-ready.

--- a/README.md
+++ b/README.md
@@ -1,158 +1,53 @@
 # ColdVox
-> ⚠️ **Internal Alpha** - This project is in early development and not ready for production use.
 
-> **⚠️ CRITICAL**: Documentation and feature status changes quickly. See [`docs/plans/current-status.md`](docs/plans/current-status.md) for what currently works.
+> Internal alpha. This repository is under active cleanup and the Windows path is still being hardened.
 
-Minimal root README. Assistants should read [`AGENTS.md`](AGENTS.md).
+ColdVox is a Rust voice pipeline: audio capture -> VAD -> STT -> text injection.
 
-## North Star
+## Current Reality
 
-Current product and documentation direction is anchored in:
+- The checked-in default config stays deterministic and test-friendly: `config/default.toml` starts with the `mock` STT path.
+- The supported Windows live path for this wave is `parakeet` on NVIDIA/CUDA hardware.
+- The Windows GUI is not the shipped path for this wave. `cargo run -p coldvox-gui` is only a stub smoke check.
+- CI is not the gate for this wave. Local Windows validation is the gate.
 
-- [`docs/northstar.md`](docs/northstar.md)
-- [`docs/plans/current-status.md`](docs/plans/current-status.md)
-- [`docs/architecture.md`](docs/architecture.md)
+## Windows Live Path
 
-## Quick Start
+Prerequisites:
 
-Status varies by STT backend and platform. For current "what works" details, see [`docs/plans/current-status.md`](docs/plans/current-status.md).
+- Windows 11
+- NVIDIA GPU with working CUDA support
+- A downloaded Parakeet model directory exposed through `PARAKEET_MODEL_PATH`
 
-```bash
-# Main app
-cargo run -p coldvox-app --bin coldvox
+Commands:
 
-# TUI dashboard
-cargo run -p coldvox-app --bin tui_dashboard
+```powershell
+just windows-run-preflight
+just windows-smoke
+just test
 ```
 
-Common Rust commands:
+To opt into the live runtime during the test gate:
 
-```bash
-# Fast local feedback
+```powershell
+$env:COLDVOX_RUN_WINDOWS_LIVE = '1'
+just test
+```
+
+To run the live validation directly:
+
+```powershell
+just windows-live
+```
+
+Validation artifacts are written under `logs/windows-validation/<timestamp>-<mode>/`.
+
+## Developer Commands
+
+```powershell
 cargo check -p coldvox-app
-
-# Format check
 cargo fmt --all -- --check
 ```
-## Development
- - Install Rust (stable) and required system dependencies for your platform.
- - Use the provided scripts in `scripts/` to help with local environment setup.
 
-### Developer Git Hooks
-
-This project uses a "Zero-Latency" git hook standard powered by **[mise](https://mise.jdx.dev)** and **lint-staged**.
-
-### Setup
-1. **Install mise**: `curl https://mise.run | sh` (or see [docs](https://mise.jdx.dev/getting-started.html))
-2. **Install dependencies**: `mise install`
-3. **Activate hooks**: `mise run prepare` (runs automatically on `npm install`)
-
-Hooks will now run automatically on `git commit`. To run manually:
-```bash
-mise run pre-commit
-```
-
-# ColdVox
-
-> ⚠️ **Internal Alpha** - This project is in early development and not ready for production use.
-
-Minimal root README. Full developer & architecture guide: see [`CLAUDE.md`](CLAUDE.md).
-
-## Overview
-ColdVox is a modular Rust workspace providing real‑time audio capture, VAD, STT (Faster-Whisper), and cross‑platform text injection.
-
-## Quick Start
-
-**For Voice Dictation (Recommended):**
-```bash
-# Run with default Faster-Whisper STT and text injection (model auto-discovered)
-cargo run --features text-injection
-
-# With specific microphone device
-cargo run --features text-injection -- --device "HyperX QuadCast"
-
-# TUI Dashboard with controls
-cargo run --bin tui_dashboard --features tui
-```
-
-**Other Usage:**
-```bash
-# VAD-only mode (no speech recognition)
-cargo run
-
-# Test microphone setup
-cargo run --bin mic_probe -- list-devices
-```
-
-> Audio dumps: The TUI dashboard now records raw audio to `logs/audio_dumps/` by default. Pass `--dump-audio=false` to disable persistent capture.
-
-**STT Backends**: ColdVox supports multiple STT engines.
-- **Parakeet**: NVIDIA-only, high performance (default if compiled).
-- **Moonshine**: CPU-optimized, fast fallback.
-
-See [Feature Flags & Hardware Config](docs/reference/feature_flags.md) for detailed hardware recommendations.
-
-**Note on Defaults**: The `default` feature set enables VAD. You **must** enable an STT backend feature (`parakeet` or `moonshine`) to get speech recognition.
-```bash
-# Universal build (recommended)
-cargo run --features "parakeet,moonshine"
-```
-
-### Configuration (Canonical Path)
-- Canonical STT selection config lives at `config/plugins.json`.
-- Any legacy duplicates like `./plugins.json` or `crates/app/plugins.json` are deprecated and ignored at runtime. A warning is logged on startup if they exist. Please migrate changes into `config/plugins.json` only.
-- Some defaults can also be set in `config/default.toml`, but `config/plugins.json` is the source of truth for STT plugin selection.
-
-### Whisper Model Setup
-- **Python Package**: Install the `faster-whisper` Python package via pip
-- **Models**: Whisper models are automatically downloaded on first use
-- **Model Identifiers**: Use standard Whisper model names (e.g., "tiny.en", "base.en", "small.en", "medium.en")
-- **Manual Path**: Set `WHISPER_MODEL_PATH` to specify a model identifier or custom model directory
-- **Common Models**:
-  - "tiny.en" (~39MB) - Fastest, lower accuracy
-  - "base.en" (~142MB) - Good balance of speed and accuracy
-  - "small.en" (~466MB) - Better accuracy
-  - "medium.en" (~1.5GB) - High accuracy
-
-## How It Works
-1. **Always-on pipeline**: Audio capture, VAD, STT, and text-injection buffering run continuously by default. Raw 16 kHz mono audio is recorded to `logs/audio_dumps/` for later review.
-2. **Voice activation (default)**: The Silero VAD segments speech automatically—no hotkey required.
-3. **Push-to-talk (preview inject)**: Hold `Super+Ctrl` to stream buffered text into the preview/injection window when you need manual control. Release to stop feeding new text.
-
-More detail: See [`CLAUDE.md`](CLAUDE.md) for full developer guide.
-
-### Python 3.13 and PyO3
-If your system default Python is 3.13, current `pyo3` versions may warn about unsupported Python version during build. Two options:
-
-1) Prefer Python 3.12 for development tools, or
-2) Build using the stable Python ABI by exporting:
-
-```bash
-set -gx PYO3_USE_ABI3_FORWARD_COMPATIBILITY 1  # fish shell
-cargo check
-```
-
-We plan to upgrade `pyo3` in a follow-up to remove this requirement.
-
-### Future Vision (Experimental)
-- We're actively exploring an **always-on intelligent listening** architecture that keeps a lightweight listener running continuously and spins up tiered STT engines on demand.
-- This speculative work includes decoupled listening/processing threads, dynamic STT memory management, and context-aware activation.
-- Read the full experimental plan in [`docs/architecture.md`](docs/architecture.md#coldvox-future-vision). Treat it as research guidance—not a committed roadmap.
-
-## Slow / Environment-Sensitive Tests
-Some end‑to‑end tests exercise real injection & STT. Gate them locally by setting an env variable (planned):
-```bash
-export COLDVOX_SLOW_TESTS=1
-cargo test -- --ignored
-```
-Headless behavior notes: see [`docs/text_injection_headless.md`](docs/text_injection_headless.md).
-
-## License
-Dual-licensed under MIT or Apache-2.0. See `LICENSE-MIT` and `LICENSE-APACHE` if present, else crate-level manifests.
-
-## Contributing
-
-- Review the [North Star](docs/northstar.md) and [current status](docs/plans/current-status.md).
-- Follow the repository [Documentation Standards](docs/standards.md).
-- Coordinate work through the [Documentation Todo Backlog](docs/todo.md).
-- Assistants should read the [Assistant Interaction Index](docs/agents.md).
+For the detailed Windows operator path, see [`docs/windows-live-runbook.md`](docs/windows-live-runbook.md).
+For agent/developer repo truth, see [`AGENTS.md`](AGENTS.md) and [`docs/plans/current-status.md`](docs/plans/current-status.md).

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -19,11 +19,15 @@ See `Cargo.toml` in each crate for Rust dependencies. Key runtime dependencies:
 
 - **Audio**: `cpal` (cross-platform audio), `rtrb` (ring buffer)
 - **VAD**: `voice_activity_detector` (Silero ONNX VAD)
-- **STT**: `parakeet-rs` (NVIDIA Parakeet), `pyo3` (Python bindings for Moonshine)
+- **STT**: `parakeet-rs` is the supported Windows live path for this wave and expects a local Parakeet model directory on NVIDIA/CUDA hardware. `pyo3` remains in the tree for older Moonshine-related paths, but it is not the primary Windows validation path.
 - **Text Injection**: `enigo`, `atspi`, `wl-clipboard` bindings
 - **TUI**: `ratatui`, `crossterm`
 
+For day-to-day local validation, the checked-in default path remains `mock`; live Windows runs opt into `parakeet` through `config/windows-parakeet.toml`.
+
 ## Tooling
+
+The tooling and CI sections below remain useful background, but they are not the release gate for the current Windows validation wave. Local Windows validation is the active gate for this pass.
 
 ### Security Scanning
 

--- a/docs/domains/foundation/fdn-testing-guide.md
+++ b/docs/domains/foundation/fdn-testing-guide.md
@@ -1,240 +1,69 @@
 ---
 doc_type: reference
 subsystem: foundation
-status: draft
-freshness: stale
+status: active
+freshness: current
 preservation: preserve
 domain_code: fdn
-last_reviewed: 2025-10-19
+last_reviewed: 2026-04-17
 owners: Documentation Working Group
 version: 1.0.0
 ---
 
 # Testing Guide
 
-## Overview
+## Current Gate
 
-ColdVox has a comprehensive test suite that tests real STT functionality using modern speech recognition models and actual hardware. Tests are designed to work with actual speech recognition and real audio devices rather than mocks to ensure functional correctness. This guide explains how to run tests and set up the required dependencies.
+For this wave, the authoritative gate is local Windows validation. CI is not the gate.
 
-## Test Categories
+On Windows, `just test` runs the required Windows-safe matrix. It does not call `cargo test --workspace --locked`, because the wider workspace still pulls in non-Windows members that are not a useful Windows correctness signal.
 
-### Core Tests
-**All tests use real STT models and hardware for functional validation**
+## Required Windows Matrix
 
-- ✅ **Test actual STT functionality** (use real Moonshine or Parakeet models)
-- ✅ **Validate end-to-end pipeline behavior**
-- ✅ **Test with real audio hardware** (microphones, speakers)
-- ✅ **Require STT model setup** (see setup section below)
+`just test` runs:
 
-```bash
-# Run tests with Moonshine (CPU-efficient)
-cargo test
+- `cargo test -p coldvox-foundation --lib --locked`
+- `cargo test -p coldvox-audio --lib --locked`
+- `cargo test -p coldvox-vad --lib --locked`
+- `cargo test -p coldvox-telemetry --lib --locked`
+- `cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked`
+- `cargo test -p coldvox-gui --lib --locked`
+- `cargo test -p coldvox-text-injection --lib --no-default-features --features enigo --locked`
+- `cargo test -p coldvox-text-injection --example test_enigo_live --no-run --no-default-features --features enigo --locked`
+- `cargo test -p coldvox-app --test settings_test --locked`
+- `cargo test -p coldvox-app --test verify_mock_injection_fix --locked`
+- `cargo test -p coldvox-app --test golden_master --locked`
+- `just windows-smoke`
 
-# Run tests for specific crate
-cargo test -p coldvox-app
+## Optional Live GPU Gate
 
-# Run with Parakeet (GPU-accelerated)
-cargo test --features parakeet
+The live runtime is optional during the default test gate and is controlled by one opt-in variable:
+
+```powershell
+$env:COLDVOX_RUN_WINDOWS_LIVE = '1'
+just test
 ```
 
-### Integration Tests (Full Hardware & Models)
-**All tests run by default - no tests are ignored**
+That opt-in adds `just windows-live` to the end of the Windows test matrix.
 
-- ✅ **Use real external models/hardware**
-- ✅ **Comprehensive end-to-end validation**
-- ✅ **Run in all environments** (dev, self-hosted CI)
-- ✅ **Test real-world functionality end-to-end**
+## Direct Validation Commands
 
-```bash
-# Run all tests (includes integration tests)
-cargo test
-
-# Run specific integration test
-cargo test test_end_to_end_wav_pipeline --nocapture
-
-# Run with real hardware (available in all environments)
-cargo test test_candidate_order_default_first
+```powershell
+just windows-run-preflight
+just windows-smoke
+just windows-live
 ```
 
-## Environment Setup
+## Live Prerequisites
 
-### Hardware Requirements
-**All environments must have real hardware available**
+- Windows 11
+- NVIDIA GPU with working CUDA support
+- A downloaded local Parakeet model directory exposed through `PARAKEET_MODEL_PATH`
 
-All tests use real STT models and actual audio hardware to validate functionality. This includes development environments and self-hosted CI runners.
+If the Parakeet model is missing, `just windows-run-preflight` and `just windows-live` fail early with a prerequisite error instead of failing later during plugin startup.
 
-### Required Setup
+## Notes
 
-#### 1. STT Model Setup
-Tests support multiple STT backends. Choose based on your environment:
-
-**Option A: Moonshine (CPU-efficient, recommended for most users)**
-```bash
-# Moonshine models are auto-downloaded on first use
-# No manual setup required - the plugin handles model initialization
-cargo test
-```
-
-**Option B: Parakeet (GPU-accelerated)**
-```bash
-# Requires CUDA/GPU support
-cargo test --features parakeet
-```
-
-> **Note:** Parakeet tests require a working parakeet-rs installation (not yet validated). Use `--features moonshine` for current working STT tests.
-
-**Option C: Mock (testing/development)**
-```bash
-# For testing without actual models
-cargo test --features mock
-```
-
-#### 2. Audio Hardware Setup
-**Real audio hardware is required and available in all environments:**
-
-```bash
-# Check available devices
-cargo run --bin mic_probe
-
-# All environments have working audio devices
-# No mocking or headless overrides are used
-```
-
-#### 3. Text Injection Setup (Linux)
-For text injection integration tests:
-
-```bash
-# Install dependencies
-./scripts/setup_text_injection.sh
-
-# Ensure proper permissions for uinput devices
-sudo usermod -a -G input $USER
-# Log out and back in after group change
-```
-
-## Test Organization
-
-### By Crate
-
-| Crate | Unit Tests | Integration Tests | Notes |
-|-------|------------|-------------------|-------|
-| `coldvox-audio` | Device enumeration, resampling | Real hardware detection | All tests run with real devices |
-| `coldvox-app` | Plugin management, STT logic | End-to-end WAV processing | STT model required for all tests |
-| `coldvox-vad` | VAD algorithms | Real audio processing | Silero ONNX models tested |
-| `coldvox-stt` | Plugin interfaces | Model loading/inference | Real hardware and models used |
-
-### By Feature
-
-```bash
-# Audio tests (with real hardware)
-cargo test -p coldvox-audio
-
-# STT tests (with available models)
-cargo test -p coldvox-app stt --lib
-
-# Text injection tests (with real injection)
-cargo test -p coldvox-app --features text-injection injection
-
-# VAD tests (with real audio processing)
-cargo test -p coldvox-vad
-
-# Full pipeline with Moonshine (CPU)
-cargo test -p coldvox-app test_end_to_end_wav
-
-# Full pipeline with Parakeet (GPU)
-cargo test -p coldvox-app test_end_to_end_wav --features parakeet
-```
-
-## Key Testing Principles
-
-### Real Hardware Testing
-- **Use real hardware**: All tests run against actual audio devices and STT models
-- **No mock-only paths**: If mocks are used for unit testing, full real tests must be included in the same test run
-- **Comprehensive**: Test actual functionality end-to-end with real hardware and models
-- **Reliable**: Target hardware is consistently available across environments
-
-### Test Design
-- **No ignored tests**: All tests run by default in standard test execution
-- **Real dependencies**: Use actual STT models and audio hardware for validation
-- **Full validation**: Test complete pipeline from audio capture to text injection
-- **Mock + Real requirement**: Any test suite using mocks must also include corresponding real tests
-
-## Common Issues & Solutions
-
-### "Failed to initialize STT plugin" Errors
-```bash
-# Moonshine: Models auto-download on first use (may take a moment)
-# Parakeet: Requires GPU/CUDA support available
-# Mock: Use --features mock for testing without models
-
-# Verify your setup
-cargo run --bin mic_probe
-cargo test -p coldvox-audio  # Test audio independently first
-```
-
-### Audio Device Tests
-```bash
-# Check available devices (should always have devices in all environments)
-cargo run --bin mic_probe
-
-# All tests run against real hardware
-cargo test
-```
-
-### Test Execution
-All tests are designed to run with real hardware and models:
-
-1. Ensure STT models are available (Moonshine auto-downloads, or select appropriate feature)
-2. Verify audio hardware is accessible via `mic_probe`
-3. All tests run by default - no tests should be ignored
-
-### Permission Errors (Linux)
-```bash
-# Fix uinput permissions for text injection
-sudo usermod -a -G input $USER
-sudo chmod 666 /dev/uinput
-```
-
-## Test Commands Reference
-
-```bash
-# Development workflow (all tests with real hardware)
-cargo test                                    # All tests including integration
-cargo check --all-targets                    # Quick compile check
-cargo test --workspace                       # All crates with real hardware
-
-# STT-specific tests
-cargo test                                   # Default: Moonshine
-cargo test --features parakeet               # GPU: Parakeet
-cargo test --features mock                   # Testing: Mock plugin
-
-# Specific test patterns
-cargo test plugin_manager                    # Plugin management tests
-cargo test audio_device                      # Audio hardware tests (real devices)
-
-# Debug failing tests
-cargo test failing_test_name -- --nocapture  # Show full output
-RUST_LOG=debug cargo test test_name          # Enable debug logging
-```
-
-## Continuous Integration
-
-**Self-hosted runners with real hardware:**
-- ✅ All tests run with real audio devices and models
-- ✅ No tests are ignored or skipped
-- ✅ Full hardware validation in CI environment
-- ✅ Compilation checks for all feature combinations
-
-**Local development:**
-- Run `cargo test` for complete validation (includes all tests)
-- All tests use real hardware and models
-- Models are automatically downloaded when needed (Moonshine)
-
-## STT Plugin Selection
-
-| Plugin | Use Case | Requirements |
-|--------|----------|--------------|
-| **Moonshine** | Production, CPU | Pure Rust, auto-downloads models |
-| **Parakeet** | High-quality, GPU | CUDA/GPU support required |
-| **Mock** | Testing, CI | No external dependencies |
-| **NoOp** | Debug, validation | Returns empty transcripts |
+- The checked-in default config stays on `mock` so tests remain deterministic.
+- The Windows live path opts into `config/windows-parakeet.toml`.
+- `coldvox-gui` is only a stub smoke target for this wave.

--- a/docs/domains/telemetry/tele-logging.md
+++ b/docs/domains/telemetry/tele-logging.md
@@ -15,7 +15,9 @@ review_due: 2026-08-12
 
 ## Overview
 
-ColdVox uses the `tracing` crate for structured logging with configurable verbosity levels. Logs are written to both stderr (console) and a daily-rotated file in `logs/coldvox.log`.
+ColdVox uses `tracing` for structured logging. Runtime logs go to stderr and the rotating file at `logs/coldvox.log`.
+
+For the Windows validation flow, the wrapper also writes per-run artifacts under `logs/windows-validation/<timestamp>-<mode>/`, including captured stdout/stderr, a copied `coldvox.log`, and a short summary file.
 
 ## Log Levels
 
@@ -111,14 +113,14 @@ RUST_LOG=info,coldvox_audio::detector=debug cargo run
 
 Logs are written to:
 - Console: stderr
-- File: `logs/coldvox.log` (current day)
-- Rotated: `logs/coldvox.log.YYYY-MM-DD` (previous days)
+- File: `logs/coldvox.log`
+- Windows validation artifacts: `logs/windows-validation/<timestamp>-<mode>/`
 
 ### Rotation
 
-- Logs rotate daily at midnight
-- Old logs are automatically pruned after 7 days (configurable)
-- File logs have ANSI codes disabled for clean analysis
+- `logs/coldvox.log` rotates daily
+- Old runtime logs are pruned according to the app's retention settings
+- Validation artifacts are per-run snapshots and are kept until you remove them
 
 ### Viewing Logs
 
@@ -175,16 +177,8 @@ RUST_LOG=info,stt_debug=trace cargo run
 
 For production use, keep logging at INFO or WARN level.
 
-## Recent Changes
+## Windows Validation Notes
 
-As of this commit:
-
-1. **Default level changed from DEBUG to INFO** to reduce verbosity
-2. **High-frequency logs downgraded**:
-   - Silence detector: INFO → DEBUG
-   - Audio chunk dispatch: INFO → TRACE
-   - Plugin process calls: DEBUG → TRACE
-   - Plugin process results: DEBUG → TRACE (success) / WARN (errors)
-3. **Documentation improved** with examples for common use cases
-
-These changes significantly reduce log noise while maintaining useful operational feedback. Users who need detailed debugging can still enable it via `RUST_LOG=debug` or `RUST_LOG=trace`.
+- `just windows-run-preflight` verifies the live prerequisites and emits artifacts even before the full runtime starts.
+- `just windows-smoke` captures the CLI and GUI stub smoke outputs in the same artifact structure.
+- `just windows-live` captures runtime stdout/stderr plus a copy and tail of `logs/coldvox.log`.

--- a/docs/plans/current-status.md
+++ b/docs/plans/current-status.md
@@ -6,30 +6,34 @@ status: active
 
 # Current Product Direction & Reality
 
-*Audited April 2026. This is the source of truth for repository structure and branch strategy.*
+Audited April 17, 2026.
 
-## Branch Strategy & Mainlines
+## Branch Strategy
 
-- **`main`**: The legacy Qt-based path. Currently stable but deprecated.
-- **`tauri-base`**: The **integration branch and future mainline**. This branch accumulates the Tauri v2 GUI migration, dead code removal, HTTP-remote STT plugin, and lint gates. Agent PRs and feature branches should target `tauri-base` moving forward until it is promoted to `main`.
+- `main` is the branch to build on.
+- The older Qt remediation line from closed PR `#389` is not a valid base for new work.
+- New stacked work should start from `origin/main` or from the latest intentional stack tip built on `main`.
 
-## Target Environment
+## Windows Runtime Reality
 
-- **OS:** Windows 11 priority.
-- **Python Environment:** Exclusively managed by `uv`. Do NOT use `mise` or raw `pip` for Python packages. Ensure `.python-version` is respected.
+- The checked-in default startup config remains deterministic: `config/default.toml` uses `mock`.
+- The supported Windows live path is `parakeet` on NVIDIA/CUDA hardware via `config/windows-parakeet.toml`.
+- Live Windows runs must supply a local Parakeet model directory through `PARAKEET_MODEL_PATH`.
+- `config/plugins.json` is persistence for plugin selection state, not the primary operator-facing startup config.
 
-## STT Backend Reality
+## Validation Reality
 
-- **Current Working (Legacy):** **Moonshine** is the current working backend but is a fragile dependency due to PyO3/Python 3.13 instabilities. It is being phased out.
-- **Forward Path (Tauri-base):** **HTTP-Remote Parakeet**. A pure-Rust HTTP plugin (`HttpRemotePlugin`) is code-complete and designed to speak to a local, containerized Parakeet STT service optimized for NVIDIA CUDA/DirectML.
-- **Vaporware:** The `whisper`, `coqui`, `leopard`, and `silero-stt` feature flags are dead stubs. They have been purged in `tauri-base` / PR #384.
+- The authoritative gate for this wave is local Windows validation, not CI.
+- `just windows-run-preflight` checks GPU/CUDA prerequisites and the local Parakeet model requirement.
+- `just windows-smoke` validates CLI help, device enumeration, and the GUI stub smoke path.
+- `just test` runs the Windows-safe required matrix on Windows and keeps the live runtime behind `COLDVOX_RUN_WINDOWS_LIVE=1`.
+- Validation artifacts are written under `logs/windows-validation/<timestamp>-<mode>/`.
 
 ## GUI Reality
 
-- **Tauri v2 Shell:** ~80% complete on a UI contract level (React + Rust state machine). It is currently a demo/mock driver.
-- **Missing Integration:** The last mile—wiring the real audio/STT pipeline (HTTP-remote Parakeet) and Text Injection into the Tauri shell—is at 0% and is the highest priority next step to make `tauri-base` functional.
+- `coldvox-gui` is not the shipped Windows path for this wave.
+- `cargo run -p coldvox-gui` is kept only as a stub smoke check.
 
-## Known Blockers & Bugs
+## Known Live Blocker
 
-- **Memory Leaks:** PyO3/Moonshine unloading does not fully release memory on Windows 11.
-- **Integration Gaps:** Text-injection can report false-positive "green" status when backends are skipped. True containerized validation for Parakeet has not been conducted.
+- A Windows machine without a downloaded local Parakeet model directory will fail `just windows-run-preflight` and `just windows-live` until `PARAKEET_MODEL_PATH` is set or the model is placed in the expected local cache path.

--- a/docs/windows-live-runbook.md
+++ b/docs/windows-live-runbook.md
@@ -1,0 +1,69 @@
+# Windows Live Runbook
+
+This runbook is the operator path for the current Windows validation wave.
+
+## Prerequisites
+
+- Windows 11
+- NVIDIA GPU with working CUDA support
+- A downloaded local Parakeet model directory
+- `PARAKEET_MODEL_PATH` pointing at that model directory
+
+## Commands
+
+Preflight:
+
+```powershell
+just windows-run-preflight
+```
+
+Smoke:
+
+```powershell
+just windows-smoke
+```
+
+Required local test gate:
+
+```powershell
+just test
+```
+
+Opt into the live runtime during the test gate:
+
+```powershell
+$env:COLDVOX_RUN_WINDOWS_LIVE = '1'
+just test
+```
+
+Run the live runtime directly:
+
+```powershell
+just windows-live
+```
+
+## Artifacts
+
+Each validation run writes artifacts to:
+
+```text
+logs/windows-validation/<timestamp>-<mode>/
+```
+
+That directory contains:
+
+- captured stdout
+- captured stderr
+- `summary.txt`
+- copied runtime log files when the live runtime starts
+
+## Review / Merge Protocol
+
+For this wave, local artifacts are the review gate.
+
+1. Run the relevant local Windows commands and keep the artifact path.
+2. Put the exact commands, hardware assumptions, and artifact path in the PR description.
+3. Wait 5 minutes for review comments before merging.
+4. Re-run the relevant local gate after addressing review feedback.
+
+CI is not the release gate for this wave.


### PR DESCRIPTION
## Summary
- rewrite the authoritative docs around the actual Windows validation path
- add a focused Windows live runbook with artifact paths and review protocol
- make the repo status and agent docs honest about the GUI stub and no-CI gate for this wave

## Local validation
- `just windows-smoke`
- `just windows-run-preflight` (fails early without a local Parakeet model)
- doc commands were checked against the stacked code state from PR2

## Hardware assumptions
- Windows 11
- NVIDIA GeForce RTX 5090
- CUDA visible through `nvidia-smi`
- local Parakeet model still required via `PARAKEET_MODEL_PATH`

## Artifacts
- smoke: `D:\_projects\.trees\coldvox-windows-pr3-runbook\logs\windows-validation\20260417-181450-082-smoke\`
- preflight: `D:\_projects\.trees\coldvox-windows-pr3-runbook\logs\windows-validation\20260417-181450-082-preflight\`
