### PR TITLE
test: add Windows local validation gate

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ lint:
 
 # Run all tests
 test:
-    cargo test --workspace --locked
+    if ($IsWindows) { just windows-test } else { cargo test --workspace --locked }
 
 # Build all crates
 build:
@@ -66,6 +66,24 @@ windows-smoke:
 
 windows-live:
     pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Live
+
+# Windows-local test gate. Keep the required matrix package-scoped so it stays
+# meaningful on Windows even while the wider workspace still includes
+# non-Windows members.
+windows-test:
+    cargo test -p coldvox-foundation --lib --locked
+    cargo test -p coldvox-audio --lib --locked
+    cargo test -p coldvox-vad --lib --locked
+    cargo test -p coldvox-telemetry --lib --locked
+    cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked
+    cargo test -p coldvox-gui --lib --locked
+    cargo test -p coldvox-text-injection --lib --no-default-features --features enigo --locked
+    cargo test -p coldvox-text-injection --example test_enigo_live --no-run --no-default-features --features enigo --locked
+    cargo test -p coldvox-app --test settings_test --locked
+    cargo test -p coldvox-app --test verify_mock_injection_fix --locked
+    cargo test -p coldvox-app --test golden_master --locked
+    just windows-smoke
+    if ($env:COLDVOX_RUN_WINDOWS_LIVE -eq '1') { just windows-live } else { Write-Host 'Skipping just windows-live; set COLDVOX_RUN_WINDOWS_LIVE=1 to opt in.' -ForegroundColor Yellow }
 
 # Run main app with the canonical wave-1 HTTP remote profile
 run:

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ lint:
 
 # Run all tests
 test:
-    if ($IsWindows) { just windows-test } else { cargo test --workspace --locked }
+    {{ if os_family() == "windows" { "just windows-test" } else { "cargo test --workspace --locked" } }}
 
 # Build all crates
 build:


### PR DESCRIPTION
## Summary
- make `just test` meaningful on Windows by routing it to a Windows-safe local matrix
- add `windows-test` with the required package-scoped test set and smoke validation
- keep the live runtime behind one opt-in gate: `COLDVOX_RUN_WINDOWS_LIVE=1`

## Local validation
- `just test`

## Hardware assumptions
- Windows 11
- NVIDIA GeForce RTX 5090
- CUDA visible through `nvidia-smi`
- no local Parakeet model installed during this run, so the live path stayed opt-in and unexecuted

## Artifacts
- smoke from the Windows test gate: `D:\_projects\.trees\coldvox-windows-pr2-tests\logs\windows-validation\20260417-181113-066-smoke\`
