### PR TITLE
fix: improve parakeet discovery and slim agent entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,56 @@
 # AGENTS.md
 
-Canonical AI agent instructions for ColdVox.
+Canonical agent entrypoint for ColdVox.
 
-## Repo Truth
+## Read First
 
-- Windows 11 is the priority environment.
-- The checked-in startup config is intentionally test-friendly: `config/default.toml` defaults to `mock`.
-- The supported Windows live path for this wave is `COLDVOX_CONFIG_PATH=config/windows-parakeet.toml` plus `PARAKEET_MODEL_PATH` on NVIDIA/CUDA hardware.
-- `config/plugins.json` is plugin-manager persistence, not the operator-facing startup source of truth.
-- The Windows GUI is out of scope for this wave. `coldvox-gui` is a stub smoke target only.
-- CI is not the authoritative gate for this wave. Local Windows validation is.
+1. [README.md](/D:/_projects/ColdVox/README.md)
+2. [docs/reference/crates/app.md](/D:/_projects/ColdVox/docs/reference/crates/app.md)
+3. [docs/domains/foundation/fdn-testing-guide.md](/D:/_projects/ColdVox/docs/domains/foundation/fdn-testing-guide.md)
+4. [docs/logging.md](/D:/_projects/ColdVox/docs/logging.md)
 
-## Recent Branch Reality
+For substantial work, read the relevant crate reference under [docs/reference/crates](/D:/_projects/ColdVox/docs/reference/crates) and the matching domain docs under [docs/domains](/D:/_projects/ColdVox/docs/domains).
 
-- `main` contains the current trunk we should build on.
-- The old Qt remediation line from closed PR `#389` is not a valid base for new work.
-- Start fresh branches from `origin/main` or from the current stacked branch tip, never from the old remediation line.
+## Precedence
 
-## Commands
+When guidance conflicts, use this order:
 
-Crate-scoped commands are still preferred for iteration:
+1. Code and tests
+2. The task-specific crate/domain docs
+3. [README.md](/D:/_projects/ColdVox/README.md)
+4. This file
 
-```powershell
-cargo check -p coldvox-stt
-cargo test -p coldvox-foundation --lib --locked
-cargo test -p coldvox-app --test golden_master --locked
-cargo fmt --all -- --check
-```
+[docs/architecture.md](/D:/_projects/ColdVox/docs/architecture.md) is useful for long-range context, but it is not the source of truth for current runtime behavior.
 
-Windows local validation:
+## Repo Truths
 
-```powershell
-just windows-run-preflight
-just windows-smoke
-just test
-```
-
-Optional live validation during the Windows test gate:
-
-```powershell
-$env:COLDVOX_RUN_WINDOWS_LIVE = '1'
-just test
-```
-
-Direct live validation:
-
-```powershell
-just windows-live
-```
+- ColdVox is a Rust workspace for audio capture, VAD, STT routing, and text injection.
+- Windows is the priority environment.
+- `config/default.toml` is the checked-in startup config and currently defaults STT to `mock`.
+- `config/plugins.json` is plugin-manager persistence, not the primary startup config.
+- `crates/coldvox-gui` exists, but the GUI is still a stub/prototype path.
+- The canonical command surface lives in the root [justfile](/D:/_projects/ColdVox/justfile).
+- Prefer git worktrees for parallel work under `../.trees/coldvox-{branch-name}`.
 
 ## Working Rules
 
-- Prefer the local Windows gate over CI status for this wave.
-- Keep the default path deterministic for tests; do not flip the checked-in default away from `mock`.
-- Only claim the Windows live path is validated when you have local artifacts under `logs/windows-validation/`.
-- Do not describe the GUI as Windows-ready.
+- Prefer crate-scoped Rust commands for iteration; use workspace-wide commands only when needed.
+- Validate changes before claiming success. Start with the smallest relevant check, then widen only as needed.
+- Keep documentation changes thin and link-heavy; do not turn root agent docs into a second README.
+- Update [CHANGELOG.md](/D:/_projects/ColdVox/CHANGELOG.md) only for user-visible changes, following [docs/standards.md](/D:/_projects/ColdVox/docs/standards.md).
+
+## Ask First
+
+- Force pushes, rebases that rewrite shared history, or branch deletion
+- Dependency changes
+- Destructive file cleanup outside the immediate task
+- Infra, release, or governance changes
+
+## Useful Routes
+
+- Runtime/config behavior: [docs/reference/crates/app.md](/D:/_projects/ColdVox/docs/reference/crates/app.md)
+- Testing and current test reality: [docs/domains/foundation/fdn-testing-guide.md](/D:/_projects/ColdVox/docs/domains/foundation/fdn-testing-guide.md)
+- Logging and runtime artifacts: [docs/logging.md](/D:/_projects/ColdVox/docs/logging.md)
+- Documentation policy: [docs/standards.md](/D:/_projects/ColdVox/docs/standards.md)
+- Active documentation backlog: [docs/todo.md](/D:/_projects/ColdVox/docs/todo.md)
+- Longer-term plans and research: [docs/plans](/D:/_projects/ColdVox/docs/plans) and [docs/research](/D:/_projects/ColdVox/docs/research)

--- a/crates/coldvox-stt/src/plugins/parakeet.rs
+++ b/crates/coldvox-stt/src/plugins/parakeet.rs
@@ -153,14 +153,15 @@ impl ParakeetPlugin {
     fn resolve_model_path(&self, config: &TranscriptionConfig) -> Result<PathBuf, ColdVoxError> {
         let mut candidates = Vec::new();
         if let Ok(path) = env::var("PARAKEET_MODEL_PATH") {
-            candidates.push(PathBuf::from(path));
+            push_unique_path(&mut candidates, PathBuf::from(path));
         }
         if !config.model_path.is_empty() && config.model_path != "base.en" {
-            candidates.push(PathBuf::from(&config.model_path));
+            push_unique_path(&mut candidates, PathBuf::from(&config.model_path));
         }
         if let Some(path) = self.model_path.clone() {
-            candidates.push(path);
+            push_unique_path(&mut candidates, path);
         }
+        self.push_discovered_model_candidates(&mut candidates);
 
         for path in candidates {
             if path.is_dir() || path.is_file() {
@@ -184,10 +185,41 @@ impl ParakeetPlugin {
         }
 
         Err(SttError::LoadFailed(
-            "Parakeet model not found. Set PARAKEET_MODEL_PATH or provide a valid model_path."
+            "Parakeet model not found. Checked PARAKEET_MODEL_PATH, config model_path, local cache, and Windows shared model roots. Set PARAKEET_MODEL_PATH or provide a valid model_path."
                 .to_string(),
         )
         .into())
+    }
+
+    #[cfg(feature = "parakeet")]
+    fn push_discovered_model_candidates(&self, candidates: &mut Vec<PathBuf>) {
+        if let Some(cache_dir) = dirs::cache_dir() {
+            push_unique_path(
+                candidates,
+                cache_dir
+                    .join("parakeet")
+                    .join(self.variant.model_identifier()),
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            let model_id = self.variant.model_identifier();
+
+            for root in [
+                Path::new(r"D:\AIModels\speech\stt"),
+                Path::new(r"D:\AIModels\speech"),
+            ] {
+                push_repo_layout_candidates(candidates, root, model_id);
+            }
+
+            for hub_root in [
+                Path::new(r"D:\AIModels\hf\.cache\hub"),
+                Path::new(r"D:\AIModels\hf\.hf_home\hub"),
+            ] {
+                push_huggingface_snapshot_candidates(candidates, hub_root, model_id);
+            }
+        }
     }
 
     /// Verify GPU is available (CUDA required)
@@ -222,6 +254,55 @@ impl ParakeetPlugin {
 impl Default for ParakeetPlugin {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "parakeet")]
+fn push_unique_path(candidates: &mut Vec<PathBuf>, path: PathBuf) {
+    if !candidates.iter().any(|candidate| candidate == &path) {
+        candidates.push(path);
+    }
+}
+
+#[cfg(feature = "parakeet")]
+fn push_repo_layout_candidates(candidates: &mut Vec<PathBuf>, root: &Path, model_id: &str) {
+    let mut nested = root.to_path_buf();
+    let mut leaf = None;
+    for segment in model_id.split('/') {
+        nested.push(segment);
+        leaf = Some(segment);
+    }
+    push_unique_path(candidates, nested);
+
+    if let Some(leaf) = leaf {
+        push_unique_path(candidates, root.join(leaf));
+    }
+}
+
+#[cfg(feature = "parakeet")]
+fn push_huggingface_snapshot_candidates(
+    candidates: &mut Vec<PathBuf>,
+    hub_root: &Path,
+    model_id: &str,
+) {
+    let snapshots_dir = hub_root
+        .join(format!("models--{}", model_id.replace('/', "--")))
+        .join("snapshots");
+
+    let Ok(entries) = std::fs::read_dir(&snapshots_dir) else {
+        return;
+    };
+
+    let mut snapshots: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    snapshots.sort();
+    snapshots.reverse();
+
+    for snapshot in snapshots {
+        push_unique_path(candidates, snapshot);
     }
 }
 
@@ -696,5 +777,30 @@ mod tests {
 
         env::remove_var("PARAKEET_VARIANT");
         env::remove_var("PARAKEET_DEVICE");
+    }
+
+    #[cfg(feature = "parakeet")]
+    #[test]
+    fn huggingface_snapshot_candidates_use_snapshot_dirs() {
+        let temp = std::env::temp_dir().join(format!(
+            "coldvox-parakeet-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        ));
+        let snapshots_dir = temp
+            .join("models--nvidia--parakeet-tdt-1.1b")
+            .join("snapshots");
+        let older = snapshots_dir.join("0001");
+        let newer = snapshots_dir.join("0002");
+        std::fs::create_dir_all(&older).expect("create older snapshot");
+        std::fs::create_dir_all(&newer).expect("create newer snapshot");
+
+        let mut candidates = Vec::new();
+        push_huggingface_snapshot_candidates(&mut candidates, &temp, "nvidia/parakeet-tdt-1.1b");
+
+        assert_eq!(candidates, vec![newer, older]);
+        std::fs::remove_dir_all(&temp).expect("clean temp dir");
     }
 }

--- a/scripts/windows_live_validate.ps1
+++ b/scripts/windows_live_validate.ps1
@@ -47,6 +47,68 @@ function Assert-Command {
     }
 }
 
+function Add-UniqueCandidate {
+    param(
+        [System.Collections.Generic.List[string]]$Candidates,
+        [string]$Path
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($Path) -and -not $Candidates.Contains($Path)) {
+        $Candidates.Add($Path)
+    }
+}
+
+function Resolve-HuggingFaceSnapshotDirs {
+    param(
+        [string]$HubRoot,
+        [string]$ModelName
+    )
+
+    $repoDir = Join-Path $HubRoot ("models--" + ($ModelName -replace '/', '--'))
+    $snapshotsDir = Join-Path $repoDir 'snapshots'
+
+    if (-not (Test-Path $snapshotsDir)) {
+        return @()
+    }
+
+    return Get-ChildItem $snapshotsDir -Directory |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -ExpandProperty FullName
+}
+
+function Get-ParakeetModelCandidates {
+    $variant = if ($env:PARAKEET_VARIANT) { $env:PARAKEET_VARIANT.ToLowerInvariant() } else { 'tdt' }
+    $modelName = switch ($variant) {
+        'ctc' { 'nvidia/parakeet-ctc-1.1b' }
+        default { 'nvidia/parakeet-tdt-1.1b' }
+    }
+
+    $candidates = New-Object 'System.Collections.Generic.List[string]'
+
+    Add-UniqueCandidate $candidates $env:PARAKEET_MODEL_PATH
+    Add-UniqueCandidate $candidates (Join-Path (Join-Path $env:LOCALAPPDATA 'parakeet') $modelName)
+
+    $leafName = Split-Path $modelName -Leaf
+    foreach ($root in @(
+        'D:\AIModels\speech\stt',
+        'D:\AIModels\speech'
+    )) {
+        Add-UniqueCandidate $candidates (Join-Path $root ($modelName -replace '/', '\'))
+        Add-UniqueCandidate $candidates (Join-Path $root $leafName)
+    }
+
+    foreach ($hubRoot in @(
+        'D:\AIModels\hf\.cache\hub',
+        'D:\AIModels\hf\.hf_home\hub'
+    )) {
+        foreach ($snapshotDir in Resolve-HuggingFaceSnapshotDirs -HubRoot $hubRoot -ModelName $modelName) {
+            Add-UniqueCandidate $candidates $snapshotDir
+        }
+    }
+
+    return $candidates
+}
+
 function Resolve-ParakeetModelPath {
     if ($env:PARAKEET_MODEL_PATH) {
         if (-not (Test-Path $env:PARAKEET_MODEL_PATH)) {
@@ -56,20 +118,14 @@ function Resolve-ParakeetModelPath {
         return $env:PARAKEET_MODEL_PATH
     }
 
-    $variant = if ($env:PARAKEET_VARIANT) { $env:PARAKEET_VARIANT.ToLowerInvariant() } else { 'tdt' }
-    $modelName = switch ($variant) {
-        'ctc' { 'nvidia/parakeet-ctc-1.1b' }
-        default { 'nvidia/parakeet-tdt-1.1b' }
-    }
-    $cacheRoot = Join-Path $env:LOCALAPPDATA 'parakeet'
-    $cachedModelPath = Join-Path $cacheRoot $modelName
-
-    if (Test-Path $cachedModelPath) {
-        $env:PARAKEET_MODEL_PATH = $cachedModelPath
-        return $cachedModelPath
+    foreach ($candidate in Get-ParakeetModelCandidates) {
+        if (Test-Path $candidate) {
+            $env:PARAKEET_MODEL_PATH = $candidate
+            return $candidate
+        }
     }
 
-    throw "Parakeet model not found. Set PARAKEET_MODEL_PATH to a downloaded model directory or place the model under $cachedModelPath."
+    throw 'Parakeet model not found. Checked PARAKEET_MODEL_PATH, the local parakeet cache, D:\AIModels shared speech roots, and HuggingFace caches. Set PARAKEET_MODEL_PATH explicitly if your model lives elsewhere.'
 }
 
 function New-ArtifactDirectories {


### PR DESCRIPTION
## Summary
- expand Parakeet model discovery to check explicit config, local cache, shared Windows model roots, and Hugging Face snapshot caches before failing
- teach the Windows live validator to use the same broader Parakeet search order
- replace the bloated root AGENTS.md with a thin router that points agents at the real docs

## Validation
- cargo fmt --all
- cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked
- pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Preflight

## Notes
- The preflight check still fails on this machine because no parakeet-rs-compatible model was found in the searched shared roots or caches.
- This PR improves discovery and error reporting; it does not claim a successful local live Parakeet run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary: Improve Parakeet Discovery and Slim Agent Entrypoint

## Overview
This PR enhances Parakeet model discovery with a cascading search strategy and restructures the AGENTS.md file to be a slim routing document that defers to canonical documentation.

## Changes by Component

### 1. **AGENTS.md** – Canonical Agent Entrypoint
**Lines changed:** +39 / −40

Transformed from a detailed instruction guide into a lightweight entrypoint that directs users to primary documentation:

| Section | Purpose |
|---------|---------|
| **Read First** | Links to 4 core docs (README, crate reference, testing guide, logging) |
| **Precedence** | Establishes conflict-resolution order: Code/Tests → Task Docs → README → This File |
| **Repo Truths** | Factual anchors (Rust workspace, Windows priority, config paths, workspace layout) |
| **Working Rules** | Iteration guidance (crate-scoped commands, validate iteratively, thin docs, changelog policy) |
| **Ask First** | Checkpoints for force pushes, dependency changes, destructive cleanup, infra changes |
| **Useful Routes** | Quick links to runtime/config, testing, logging, standards, and planning docs |

---

### 2. **parakeet.rs** – Enhanced Model Discovery
**Lines changed:** +110 / −4  
**Estimated effort:** Medium

**Model resolution now searches in order:**

```
1. PARAKEET_MODEL_PATH environment variable
2. config.model_path (if non-empty and non-default)
3. self.model_path (plugin-configured path)
4. Discovered candidates:
   - Local cache: ${cache_dir}/parakeet/<variant>
   - [Windows] Shared roots: D:\AIModels\speech\stt, D:\AIModels\speech
   - [Windows] HuggingFace snapshots: sorted by most recent
```

**New helper functions:**
- `push_unique_path()` — Deduplicates path candidates
- `push_discovered_model_candidates()` — Aggregates cache + Windows shared roots + HF snapshots
- `push_huggingface_snapshot_candidates()` — Locates and orders HF snapshot dirs by recency (with unit test)

**Error message updated** to reflect all searched locations when model not found.

---

### 3. **windows_live_validate.ps1** – Aligned Model Resolution
**Lines changed:** +68 / −12  
**Estimated effort:** Medium

**New/Updated Functions:**

| Function | Role |
|----------|------|
| `Add-UniqueCandidate` | Deduplicates candidate paths |
| `Resolve-HuggingFaceSnapshotDirs` | Finds HF snapshots under hub root, sorted by recency |
| `Get-ParakeetModelCandidates` | Aggregates candidates from env, cache, shared roots, HF snapshots |
| `Resolve-ParakeetModelPath` (updated) | Returns first existing candidate; broader error when none found |

**Candidate precedence matches Rust implementation:**
- `PARAKEET_MODEL_PATH` (if explicitly set)
- Local cache: `${LOCALAPPDATA}\parakeet\<variant>`
- Shared roots: `D:\AIModels\speech\stt`, `D:\AIModels\speech`
- HuggingFace hubs: `D:\AIModels\hf\.cache\hub`, `D:\AIModels\hf\.hf_home\hub`

---

## Test Coverage & Validation
- ✓ `cargo fmt --all`
- ✓ `cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked`
- ✓ `pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Preflight`
- ⚠️ Preflight validation succeeds structurally; author's machine lacks compatible Parakeet model in searched locations (as expected)

## Key Benefits
| Benefit | Impact |
|---------|--------|
| **Cascading discovery** | Finds models across explicit config, local cache, shared Windows roots, and HF caches before failing |
| **Consistency** | Rust and PowerShell implementations use identical search order |
| **Better UX** | Clear error messages list all searched locations |
| **Slim agents docs** | Reduces maintenance burden by centralizing guidance in primary docs while preserving link structure |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->