### PR TITLE
fix: tighten parakeet discovery follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,13 @@ Canonical agent entrypoint for ColdVox.
 
 ## Read First
 
-1. [README.md](/D:/_projects/ColdVox/README.md)
-2. [docs/reference/crates/app.md](/D:/_projects/ColdVox/docs/reference/crates/app.md)
-3. [docs/domains/foundation/fdn-testing-guide.md](/D:/_projects/ColdVox/docs/domains/foundation/fdn-testing-guide.md)
-4. [docs/logging.md](/D:/_projects/ColdVox/docs/logging.md)
+1. [docs/index.md](docs/index.md)
+2. [docs/windows-live-runbook.md](docs/windows-live-runbook.md)
+3. [docs/reference/crates/app.md](docs/reference/crates/app.md)
+4. [docs/domains/foundation/fdn-testing-guide.md](docs/domains/foundation/fdn-testing-guide.md)
+5. [README.md](README.md) for high-level project context only
 
-For substantial work, read the relevant crate reference under [docs/reference/crates](/D:/_projects/ColdVox/docs/reference/crates) and the matching domain docs under [docs/domains](/D:/_projects/ColdVox/docs/domains).
+For substantial work, read the relevant crate reference under [docs/reference/crates](docs/reference/crates) and the matching domain docs under [docs/domains](docs/domains).
 
 ## Precedence
 
@@ -17,10 +18,11 @@ When guidance conflicts, use this order:
 
 1. Code and tests
 2. The task-specific crate/domain docs
-3. [README.md](/D:/_projects/ColdVox/README.md)
-4. This file
+3. [docs/index.md](docs/index.md) and the docs it routes you to
+4. [README.md](README.md)
+5. This file
 
-[docs/architecture.md](/D:/_projects/ColdVox/docs/architecture.md) is useful for long-range context, but it is not the source of truth for current runtime behavior.
+[docs/architecture.md](docs/architecture.md) is useful for long-range context, but it is not the source of truth for current runtime behavior.
 
 ## Repo Truths
 
@@ -29,7 +31,8 @@ When guidance conflicts, use this order:
 - `config/default.toml` is the checked-in startup config and currently defaults STT to `mock`.
 - `config/plugins.json` is plugin-manager persistence, not the primary startup config.
 - `crates/coldvox-gui` exists, but the GUI is still a stub/prototype path.
-- The canonical command surface lives in the root [justfile](/D:/_projects/ColdVox/justfile).
+- The canonical command surface lives in the root [justfile](justfile).
+- The canonical Windows-local validation path is `just windows-run-preflight`, `just windows-smoke`, `just windows-live`, and `just test` as documented in [docs/windows-live-runbook.md](docs/windows-live-runbook.md).
 - Prefer git worktrees for parallel work under `../.trees/coldvox-{branch-name}`.
 
 ## Working Rules
@@ -37,7 +40,7 @@ When guidance conflicts, use this order:
 - Prefer crate-scoped Rust commands for iteration; use workspace-wide commands only when needed.
 - Validate changes before claiming success. Start with the smallest relevant check, then widen only as needed.
 - Keep documentation changes thin and link-heavy; do not turn root agent docs into a second README.
-- Update [CHANGELOG.md](/D:/_projects/ColdVox/CHANGELOG.md) only for user-visible changes, following [docs/standards.md](/D:/_projects/ColdVox/docs/standards.md).
+- Update [CHANGELOG.md](CHANGELOG.md) only for user-visible changes, following [docs/standards.md](docs/standards.md).
 
 ## Ask First
 
@@ -48,9 +51,10 @@ When guidance conflicts, use this order:
 
 ## Useful Routes
 
-- Runtime/config behavior: [docs/reference/crates/app.md](/D:/_projects/ColdVox/docs/reference/crates/app.md)
-- Testing and current test reality: [docs/domains/foundation/fdn-testing-guide.md](/D:/_projects/ColdVox/docs/domains/foundation/fdn-testing-guide.md)
-- Logging and runtime artifacts: [docs/logging.md](/D:/_projects/ColdVox/docs/logging.md)
-- Documentation policy: [docs/standards.md](/D:/_projects/ColdVox/docs/standards.md)
-- Active documentation backlog: [docs/todo.md](/D:/_projects/ColdVox/docs/todo.md)
-- Longer-term plans and research: [docs/plans](/D:/_projects/ColdVox/docs/plans) and [docs/research](/D:/_projects/ColdVox/docs/research)
+- Runtime/config behavior: [docs/reference/crates/app.md](docs/reference/crates/app.md)
+- Windows validation commands and artifact flow: [docs/windows-live-runbook.md](docs/windows-live-runbook.md)
+- Testing and current test reality: [docs/domains/foundation/fdn-testing-guide.md](docs/domains/foundation/fdn-testing-guide.md)
+- Documentation index: [docs/index.md](docs/index.md)
+- Documentation policy: [docs/standards.md](docs/standards.md)
+- Active documentation backlog: [docs/todo.md](docs/todo.md)
+- Longer-term plans and research: [docs/plans](docs/plans) and [docs/research](docs/research)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Prerequisites:
 
 - Windows 11
 - NVIDIA GPU with working CUDA support
-- A downloaded Parakeet model directory exposed through `PARAKEET_MODEL_PATH`
+- A downloaded Parakeet model directory that is either exposed through `PARAKEET_MODEL_PATH` or available in the normal shared/local discovery roots
 
 Commands:
 

--- a/crates/coldvox-stt/src/plugins/parakeet.rs
+++ b/crates/coldvox-stt/src/plugins/parakeet.rs
@@ -175,17 +175,8 @@ impl ParakeetPlugin {
             );
         }
 
-        if let Some(cache_dir) = dirs::cache_dir() {
-            let cached_model = cache_dir
-                .join("parakeet")
-                .join(self.variant.model_identifier());
-            if cached_model.exists() {
-                return Ok(cached_model);
-            }
-        }
-
         Err(SttError::LoadFailed(
-            "Parakeet model not found. Checked PARAKEET_MODEL_PATH, config model_path, local cache, and Windows shared model roots. Set PARAKEET_MODEL_PATH or provide a valid model_path."
+            "Parakeet model not found. Checked PARAKEET_MODEL_PATH, config model_path, local cache, Windows shared model roots, and Hugging Face caches. Set PARAKEET_MODEL_PATH or provide a valid model_path."
                 .to_string(),
         )
         .into())
@@ -212,13 +203,14 @@ impl ParakeetPlugin {
             ] {
                 push_repo_layout_candidates(candidates, root, model_id);
             }
+        }
 
-            for hub_root in [
-                Path::new(r"D:\AIModels\hf\.cache\hub"),
-                Path::new(r"D:\AIModels\hf\.hf_home\hub"),
-            ] {
-                push_huggingface_snapshot_candidates(candidates, hub_root, model_id);
-            }
+        for hub_root in candidate_huggingface_hub_roots() {
+            push_huggingface_snapshot_candidates(
+                candidates,
+                &hub_root,
+                self.variant.model_identifier(),
+            );
         }
     }
 
@@ -280,6 +272,49 @@ fn push_repo_layout_candidates(candidates: &mut Vec<PathBuf>, root: &Path, model
 }
 
 #[cfg(feature = "parakeet")]
+fn candidate_huggingface_hub_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    for var in ["HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"] {
+        if let Ok(path) = env::var(var) {
+            push_unique_path(&mut roots, PathBuf::from(path));
+        }
+    }
+
+    if let Ok(path) = env::var("HF_HOME") {
+        push_unique_path(&mut roots, PathBuf::from(path).join("hub"));
+    }
+
+    if let Ok(path) = env::var("XDG_CACHE_HOME") {
+        push_unique_path(
+            &mut roots,
+            PathBuf::from(path).join("huggingface").join("hub"),
+        );
+    }
+
+    if let Some(home_dir) = dirs::home_dir() {
+        push_unique_path(
+            &mut roots,
+            home_dir.join(".cache").join("huggingface").join("hub"),
+        );
+    }
+
+    if let Some(cache_dir) = dirs::cache_dir() {
+        push_unique_path(&mut roots, cache_dir.join("huggingface").join("hub"));
+    }
+
+    #[cfg(windows)]
+    for root in [
+        PathBuf::from(r"D:\AIModels\hf\.cache\hub"),
+        PathBuf::from(r"D:\AIModels\hf\.hf_home\hub"),
+    ] {
+        push_unique_path(&mut roots, root);
+    }
+
+    roots
+}
+
+#[cfg(feature = "parakeet")]
 fn push_huggingface_snapshot_candidates(
     candidates: &mut Vec<PathBuf>,
     hub_root: &Path,
@@ -293,15 +328,25 @@ fn push_huggingface_snapshot_candidates(
         return;
     };
 
-    let mut snapshots: Vec<PathBuf> = entries
+    let mut snapshots: Vec<(std::time::SystemTime, PathBuf)> = entries
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_dir())
+        .map(|path| {
+            let modified = path
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            (modified, path)
+        })
         .collect();
-    snapshots.sort();
-    snapshots.reverse();
+    snapshots.sort_by(|(left_time, left_path), (right_time, right_path)| {
+        right_time
+            .cmp(left_time)
+            .then_with(|| left_path.cmp(right_path))
+    });
 
-    for snapshot in snapshots {
+    for (_, snapshot) in snapshots {
         push_unique_path(candidates, snapshot);
     }
 }
@@ -781,7 +826,7 @@ mod tests {
 
     #[cfg(feature = "parakeet")]
     #[test]
-    fn huggingface_snapshot_candidates_use_snapshot_dirs() {
+    fn huggingface_snapshot_candidates_prefer_newer_snapshots() {
         let temp = std::env::temp_dir().join(format!(
             "coldvox-parakeet-test-{}",
             std::time::SystemTime::now()
@@ -793,8 +838,9 @@ mod tests {
             .join("models--nvidia--parakeet-tdt-1.1b")
             .join("snapshots");
         let older = snapshots_dir.join("0001");
-        let newer = snapshots_dir.join("0002");
         std::fs::create_dir_all(&older).expect("create older snapshot");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let newer = snapshots_dir.join("0002");
         std::fs::create_dir_all(&newer).expect("create newer snapshot");
 
         let mut candidates = Vec::new();

--- a/docs/domains/foundation/fdn-testing-guide.md
+++ b/docs/domains/foundation/fdn-testing-guide.md
@@ -60,7 +60,7 @@ just windows-live
 
 - Windows 11
 - NVIDIA GPU with working CUDA support
-- A downloaded local Parakeet model directory exposed through `PARAKEET_MODEL_PATH`
+- A downloaded local Parakeet model directory available through either the standard discovery roots or `PARAKEET_MODEL_PATH`
 
 If the Parakeet model is missing, `just windows-run-preflight` and `just windows-live` fail early with a prerequisite error instead of failing later during plugin startup.
 

--- a/docs/windows-live-runbook.md
+++ b/docs/windows-live-runbook.md
@@ -7,7 +7,20 @@ This runbook is the operator path for the current Windows validation wave.
 - Windows 11
 - NVIDIA GPU with working CUDA support
 - A downloaded local Parakeet model directory
-- `PARAKEET_MODEL_PATH` pointing at that model directory
+- Either:
+  - `PARAKEET_MODEL_PATH` pointing at that directory, or
+  - the model living in one of the shared/local discovery roots that the validator checks first
+
+## Model Discovery
+
+`just windows-run-preflight` and `just windows-live` search for Parakeet in this order:
+
+1. `PARAKEET_MODEL_PATH`
+2. The local Parakeet cache
+3. Shared `D:\AIModels\speech\...` roots
+4. Standard Hugging Face cache roots such as `HF_HUB_CACHE`, `HF_HOME\hub`, and the user's local Hugging Face cache
+
+Use `PARAKEET_MODEL_PATH` only when the model lives somewhere outside those normal roots.
 
 ## Commands
 

--- a/scripts/windows_live_validate.ps1
+++ b/scripts/windows_live_validate.ps1
@@ -76,6 +76,44 @@ function Resolve-HuggingFaceSnapshotDirs {
         Select-Object -ExpandProperty FullName
 }
 
+function Get-HuggingFaceHubRoots {
+    $roots = New-Object 'System.Collections.Generic.List[string]'
+
+    foreach ($path in @(
+        $env:HF_HUB_CACHE,
+        $env:HUGGINGFACE_HUB_CACHE
+    )) {
+        Add-UniqueCandidate $roots $path
+    }
+
+    if ($env:HF_HOME) {
+        Add-UniqueCandidate $roots (Join-Path $env:HF_HOME 'hub')
+    }
+
+    if ($env:XDG_CACHE_HOME) {
+        Add-UniqueCandidate $roots (Join-Path $env:XDG_CACHE_HOME 'huggingface\hub')
+    }
+
+    foreach ($homeRoot in @($HOME, $env:USERPROFILE)) {
+        if (-not [string]::IsNullOrWhiteSpace($homeRoot)) {
+            Add-UniqueCandidate $roots (Join-Path $homeRoot '.cache\huggingface\hub')
+        }
+    }
+
+    if ($env:LOCALAPPDATA) {
+        Add-UniqueCandidate $roots (Join-Path $env:LOCALAPPDATA 'huggingface\hub')
+    }
+
+    foreach ($sharedRoot in @(
+        'D:\AIModels\hf\.cache\hub',
+        'D:\AIModels\hf\.hf_home\hub'
+    )) {
+        Add-UniqueCandidate $roots $sharedRoot
+    }
+
+    return $roots
+}
+
 function Get-ParakeetModelCandidates {
     $variant = if ($env:PARAKEET_VARIANT) { $env:PARAKEET_VARIANT.ToLowerInvariant() } else { 'tdt' }
     $modelName = switch ($variant) {
@@ -97,10 +135,7 @@ function Get-ParakeetModelCandidates {
         Add-UniqueCandidate $candidates (Join-Path $root $leafName)
     }
 
-    foreach ($hubRoot in @(
-        'D:\AIModels\hf\.cache\hub',
-        'D:\AIModels\hf\.hf_home\hub'
-    )) {
+    foreach ($hubRoot in Get-HuggingFaceHubRoots) {
         foreach ($snapshotDir in Resolve-HuggingFaceSnapshotDirs -HubRoot $hubRoot -ModelName $modelName) {
             Add-UniqueCandidate $candidates $snapshotDir
         }
@@ -125,7 +160,7 @@ function Resolve-ParakeetModelPath {
         }
     }
 
-    throw 'Parakeet model not found. Checked PARAKEET_MODEL_PATH, the local parakeet cache, D:\AIModels shared speech roots, and HuggingFace caches. Set PARAKEET_MODEL_PATH explicitly if your model lives elsewhere.'
+    throw 'Parakeet model not found. Checked PARAKEET_MODEL_PATH, the local parakeet cache, D:\AIModels shared speech roots, and standard Hugging Face caches. Set PARAKEET_MODEL_PATH explicitly if your model lives elsewhere.'
 }
 
 function New-ArtifactDirectories {


### PR DESCRIPTION
## Summary
- make Parakeet discovery check standard Hugging Face cache roots and prefer newer snapshot directories deterministically
- keep the Windows validator in sync with that broader discovery order
- fix the thin AGENTS/docs routing so it points at real current Windows validation docs instead of stale or missing targets

## Validation
- cargo fmt --all -- --check
- cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked
- just windows-smoke
- pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Preflight

## Notes
- Preflight still fails on this machine because no discoverable Parakeet model exists in the checked local/shared roots and no PARAKEET_MODEL_PATH is set.
- This PR narrows that failure to a real missing-model condition rather than a too-narrow cache search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Parakeet Model Discovery Refinements & Documentation Alignment

## Overview
This PR refines Parakeet model discovery to recognize standard Hugging Face cache roots with deterministic ordering that prefers newer snapshots. The Windows validator script and supporting documentation are aligned to match the expanded discovery strategy.

## Key Changes by Component

| File | Changes | Lines | Effort |
|------|---------|-------|--------|
| **parakeet.rs** | Removed local fallback; expanded HF root discovery from env vars & standard paths; sort snapshots by modification time (newer first) | +68/-22 | High |
| **windows_live_validate.ps1** | Added `Get-HuggingFaceHubRoots` helper; updated model candidate iteration to match Rust logic | +40/-5 | Medium |
| **AGENTS.md** | Replaced absolute paths with relative repo links; reordered "Read First" section; added Windows validation command sequence & "Model Discovery" routing | +20/-16 | Medium |
| **windows-live-runbook.md** | Added "Model Discovery" section documenting search precedence; clarified `PARAKEET_MODEL_PATH` is optional | +14/-1 | Low |
| **README.md** | Updated prerequisites to allow model discovery via standard roots OR `PARAKEET_MODEL_PATH` | +1/-1 | Low |
| **fdn-testing-guide.md** | Broadened "Live Prerequisites" to include standard discovery roots alongside `PARAKEET_MODEL_PATH` | +1/-1 | Low |

## Model Discovery Logic

### Hugging Face Hub Root Aggregation
Both Rust plugin and Windows validator now query, in order:
- Environment variables: `HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, `HF_HOME`, `XDG_CACHE_HOME`
- User directories: home cache, config home
- Windows-specific: hardcoded shared roots (`D:\AIModels\speech\...`)

### Snapshot Selection Strategy
- Collects snapshots with filesystem modification timestamps
- Sorts **descending by timestamp** (tie-broken by path)
- Drops earlier local fallback cache check; error messaging now references full HF locations

### Documentation Clarity
**AGENTS.md**: Centralized Windows validation command sequence:
```
just windows-run-preflight
just windows-smoke
just windows-live
just test
```
All pointing to `docs/windows-live-runbook.md`.

**windows-live-runbook.md**: New "Model Discovery" section explicitly documents the search order and notes that `PARAKEET_MODEL_PATH` should only be used when the model is outside standard discovery roots.

## Validation & Testing
- ✓ `cargo fmt --all -- --check`
- ✓ `cargo test -p coldvox-stt --lib --no-default-features --features parakeet --locked`
- ✓ `just windows-smoke`
- ✓ `pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Preflight`

**Known Limitation**: Preflight validation fails on author's machine when no discoverable model is available and `PARAKEET_MODEL_PATH` is unset. This is the intended behavior—the PR narrows failure conditions to actual missing-model situations rather than overly restrictive cache search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->