### PR TITLE
test(stt): live parakeet http-remote integration tests

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -57,6 +57,11 @@ path = "tests/tui_dashboard_manual_test.rs"
 name = "verify_mock_injection_fix"
 path = "tests/verify_mock_injection_fix.rs"
 
+[[test]]
+name = "http_remote_wiring_live"
+path = "tests/http_remote_wiring_live.rs"
+required-features = ["http-remote"]
+
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/app/tests/http_remote_wiring_live.rs
+++ b/crates/app/tests/http_remote_wiring_live.rs
@@ -1,0 +1,106 @@
+//! End-to-end wiring test: Settings → runtime_plugin_selection →
+//! runtime_http_remote_config → HttpRemotePlugin → real parakeet-cpu.
+//!
+//! Closes the app↔plugin integration gap that unit tests do not cover.
+//! Requires the parakeet-cpu docker-compose service on :5092. Run with:
+//!
+//! ```
+//! cargo test -p coldvox-app --features http-remote \
+//!   --test http_remote_wiring_live -- --ignored --nocapture
+//! ```
+
+#![cfg(feature = "http-remote")]
+
+use std::path::PathBuf;
+
+use coldvox_app::Settings;
+use coldvox_stt::plugin::SttPlugin;
+use coldvox_stt::plugins::http_remote::HttpRemotePlugin;
+use coldvox_stt::types::{TranscriptionConfig, TranscriptionEvent};
+use serial_test::serial;
+
+const EXPECTED_TRANSCRIPT: &str =
+    "On august twenty seventh, eighteen thirty seven, she writes.";
+
+fn repo_root() -> PathBuf {
+    // crates/app/ -> crates/ -> repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("locate repo root")
+        .to_path_buf()
+}
+
+fn load_test_1_samples() -> Vec<i16> {
+    let wav = repo_root().join("crates/app/test_data/test_1.wav");
+    let mut reader = hound::WavReader::open(&wav)
+        .unwrap_or_else(|e| panic!("open {}: {e}", wav.display()));
+    let spec = reader.spec();
+    assert_eq!(spec.sample_rate, 16_000);
+    assert_eq!(spec.channels, 1);
+    reader
+        .samples::<i16>()
+        .map(|s| s.expect("wav sample"))
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires running parakeet-cpu container on :5092"]
+#[serial]
+async fn windows_parakeet_settings_wire_through_to_real_transcript() {
+    // Mirror what scripts/run-coldvox.ps1 does on Windows: point at the
+    // windows-parakeet override. We drive Settings::from_path directly so
+    // the test does not depend on discovery order.
+    let config_path = repo_root().join("config/windows-parakeet.toml");
+    let settings = Settings::from_path(&config_path).expect("load settings");
+
+    // Step 1: the selection resolves to the canonical http-remote plugin.
+    let selection = settings
+        .runtime_plugin_selection()
+        .expect("runtime plugin selection must succeed");
+    assert_eq!(
+        selection.preferred_plugin.as_deref(),
+        Some("http-remote"),
+        "windows-parakeet.toml must wire to the http-remote plugin"
+    );
+
+    // Step 2: the resolved remote config must point at the canonical
+    // parakeet-cpu endpoint and model — same contract main.rs depends on.
+    let remote = settings.runtime_http_remote_config();
+    assert_eq!(remote.base_url, "http://localhost:5092");
+    assert_eq!(remote.api_path, "/v1/audio/transcriptions");
+    assert_eq!(remote.health_path, "/health");
+    assert_eq!(remote.model_name, "parakeet-tdt-0.6b-v2");
+
+    // Step 3: instantiate the plugin from that settings-derived config and
+    // drive it end-to-end against the real container.
+    let mut plugin = HttpRemotePlugin::new(remote);
+    assert!(
+        plugin.is_available().await.expect("health probe"),
+        "parakeet-cpu container must be healthy at http://localhost:5092/health"
+    );
+
+    plugin
+        .initialize(TranscriptionConfig::default())
+        .await
+        .expect("initialize");
+
+    plugin
+        .process_audio(&load_test_1_samples())
+        .await
+        .expect("process_audio");
+
+    let event = plugin
+        .finalize()
+        .await
+        .expect("finalize")
+        .expect("plugin must emit Final for non-empty audio");
+
+    match event {
+        TranscriptionEvent::Final { text, .. } => assert_eq!(
+            text, EXPECTED_TRANSCRIPT,
+            "settings-wired parakeet transcript drifted from canonical expected text"
+        ),
+        other => panic!("expected TranscriptionEvent::Final, got {other:?}"),
+    }
+}

--- a/crates/coldvox-stt/tests/http_remote_live.rs
+++ b/crates/coldvox-stt/tests/http_remote_live.rs
@@ -1,0 +1,84 @@
+//! Live integration test for the canonical Parakeet HTTP-remote plugin.
+//!
+//! Requires the `parakeet-cpu` docker-compose service to be running on
+//! `http://localhost:5092`. Ignored by default; run with:
+//!
+//! ```
+//! cargo test -p coldvox-stt --features http-remote \
+//!   --test http_remote_live -- --ignored --nocapture
+//! ```
+
+#![cfg(feature = "http-remote")]
+
+use std::path::PathBuf;
+
+use coldvox_stt::plugin::SttPlugin;
+use coldvox_stt::plugins::http_remote::{HttpRemoteConfig, HttpRemotePlugin};
+use coldvox_stt::types::{TranscriptionConfig, TranscriptionEvent};
+
+const EXPECTED_TRANSCRIPT: &str =
+    "On august twenty seventh, eighteen thirty seven, she writes.";
+
+fn load_test_1_samples() -> Vec<i16> {
+    let wav_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/ parent")
+        .join("app")
+        .join("test_data")
+        .join("test_1.wav");
+
+    let mut reader = hound::WavReader::open(&wav_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", wav_path.display()));
+    let spec = reader.spec();
+    assert_eq!(spec.sample_rate, 16_000, "test_1.wav must be 16 kHz");
+    assert_eq!(spec.channels, 1, "test_1.wav must be mono");
+
+    reader
+        .samples::<i16>()
+        .map(|s| s.expect("wav sample"))
+        .collect()
+}
+
+#[tokio::test]
+#[ignore = "requires running parakeet-cpu container on :5092"]
+async fn canonical_parakeet_cpu_transcribes_test_1_exactly() {
+    let mut plugin = HttpRemotePlugin::new(HttpRemoteConfig::canonical_parakeet_cpu());
+
+    assert!(
+        plugin
+            .is_available()
+            .await
+            .expect("is_available should not error"),
+        "parakeet-cpu container must be healthy at http://localhost:5092/health \
+         (run `docker compose -f ops/parakeet/docker-compose.yml up -d parakeet-cpu`)"
+    );
+
+    plugin
+        .initialize(TranscriptionConfig::default())
+        .await
+        .expect("initialize");
+
+    let samples = load_test_1_samples();
+    assert!(!samples.is_empty(), "test_1.wav yielded no samples");
+
+    plugin
+        .process_audio(&samples)
+        .await
+        .expect("process_audio");
+
+    let event = plugin
+        .finalize()
+        .await
+        .expect("finalize")
+        .expect("plugin must emit Final for non-empty audio");
+
+    match event {
+        TranscriptionEvent::Final { text, .. } => {
+            assert_eq!(
+                text, EXPECTED_TRANSCRIPT,
+                "parakeet-cpu transcript drifted from the canonical expected text"
+            );
+        }
+        other => panic!("expected TranscriptionEvent::Final, got {other:?}"),
+    }
+}

--- a/justfile
+++ b/justfile
@@ -67,6 +67,12 @@ windows-smoke:
 windows-live:
     pwsh -NoProfile -File scripts/windows_live_validate.ps1 -Mode Live
 
+# Live integration tests against the parakeet-cpu HTTP container.
+# Brings the container up via docker compose, waits for /health, then runs
+# both the plugin-level and the app-level wiring tests with -- --ignored.
+integration-parakeet:
+    pwsh -NoProfile -File scripts/integration_parakeet.ps1
+
 # Windows-local test gate. Keep the required matrix package-scoped so it stays
 # meaningful on Windows even while the wider workspace still includes
 # non-Windows members.

--- a/scripts/integration_parakeet.ps1
+++ b/scripts/integration_parakeet.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Brings up the parakeet-cpu HTTP container and runs the live integration tests.
+
+.DESCRIPTION
+    Invoked by `just integration-parakeet`. Uses ops/parakeet/docker-compose.yml to
+    start the parakeet-cpu service, waits for GET /health to return status=ok, then
+    runs both the plugin-level and app-level live integration tests with --ignored.
+
+.NOTES
+    Health timeout is configurable via COLDVOX_PARAKEET_HEALTH_TIMEOUT_SECONDS (default 180).
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ComposeFile = Join-Path $RepoRoot 'ops/parakeet/docker-compose.yml'
+if (-not (Test-Path $ComposeFile)) {
+    throw "docker-compose file not found: $ComposeFile"
+}
+
+$HealthTimeoutSeconds = if ($env:COLDVOX_PARAKEET_HEALTH_TIMEOUT_SECONDS) {
+    [int]$env:COLDVOX_PARAKEET_HEALTH_TIMEOUT_SECONDS
+} else { 180 }
+
+Write-Host "==> docker compose up -d parakeet-cpu"
+# NOTE: the container is left running on exit so subsequent cargo test invocations
+# hit a warm fixture. Tear down manually via `docker compose -f <file> down` when done.
+docker compose -f $ComposeFile up -d parakeet-cpu
+if ($LASTEXITCODE -ne 0) { throw "docker compose up failed (exit $LASTEXITCODE)" }
+
+Write-Host "==> waiting for http://localhost:5092/health (timeout ${HealthTimeoutSeconds}s)"
+$deadline = (Get-Date).AddSeconds($HealthTimeoutSeconds)
+$healthy = $false
+while ((Get-Date) -lt $deadline) {
+    try {
+        $r = Invoke-WebRequest -Uri 'http://localhost:5092/health' -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        if ($r.StatusCode -eq 200 -and $r.Content -match '"status"\s*:\s*"ok"') {
+            $healthy = $true
+            break
+        }
+    } catch {
+        # fall through to unconditional sleep below
+    }
+    Start-Sleep -Seconds 2
+}
+if (-not $healthy) {
+    throw "parakeet-cpu did not report healthy at /health within ${HealthTimeoutSeconds}s"
+}
+Write-Host "    OK"
+
+Push-Location $RepoRoot
+try {
+    Write-Host "==> cargo test -p coldvox-stt --test http_remote_live -- --ignored"
+    cargo test -p coldvox-stt --features http-remote --test http_remote_live --locked -- --ignored --nocapture
+    if ($LASTEXITCODE -ne 0) { throw "http_remote_live failed (exit $LASTEXITCODE)" }
+
+    Write-Host "==> cargo test -p coldvox-app --test http_remote_wiring_live -- --ignored"
+    cargo test -p coldvox-app --features http-remote --test http_remote_wiring_live --locked -- --ignored --nocapture
+    if ($LASTEXITCODE -ne 0) { throw "http_remote_wiring_live failed (exit $LASTEXITCODE)" }
+
+    Write-Host "==> integration-parakeet: OK"
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
Closes the test coverage gaps surfaced in the PR #409 review.

Before this PR, the only real behavioral coverage of the canonical HTTP-remote Parakeet path was the TCP-stub test inside \`crates/coldvox-stt/src/plugins/http_remote.rs\`. No test exercised the \`Settings → runtime_plugin_selection → runtime_http_remote_config → HttpRemotePlugin\` wiring, and the Windows Preflight check never touched the Rust plugin at all (it shelled out to curl).

This PR adds two \`#[ignore]\`-gated live integration tests that hit the real \`parakeet-cpu\` container and assert the **exact** transcript for \`test_1.wav\`:

- \`crates/coldvox-stt/tests/http_remote_live.rs\` — plugin-level: \`HttpRemoteConfig::canonical_parakeet_cpu()\` → real container → \`\"On august twenty seventh, eighteen thirty seven, she writes.\"\`
- \`crates/app/tests/http_remote_wiring_live.rs\` — wiring: \`Settings::from_path(\"config/windows-parakeet.toml\")\` → \`runtime_plugin_selection()\` → \`runtime_http_remote_config()\` → \`HttpRemotePlugin::new()\` → real container → same exact transcript assertion.

Both tests were regression-proven during authoring:
- Mutating \`api_path\` to \`/v1/BOGUS_REGRESSION_CHECK\` produced \`404 Not Found\` and the plugin test FAILED as required. Reverted.
- Mutating \`preferred = \"mock\"\` in \`config/windows-parakeet.toml\` produced \`left: Some(\"mock\"), right: Some(\"http-remote\")\` at the assertion **before any network call**, and the wiring test FAILED as required. Reverted.

A \`just integration-parakeet\` recipe + \`scripts/integration_parakeet.ps1\` bring up the container, wait for \`/health\`, and run both tests.

## What this catches that existing tests don't
- \`api_path\` drift (plugin URL path)
- \`model_name\` drift (canonical model name)
- Response parser regressions (exact-text equality, not substring)
- \`runtime_http_remote_config()\` field drift (base_url, api_path, health_path, model_name)
- Config → plugin wiring breakage — fails at the assertion step, proven

## Not in scope (follow-up issues will be filed)
- Linux/macOS \`.sh\` runner counterpart to \`integration_parakeet.ps1\`
- \`docs/domains/foundation/fdn-testing-guide.md\` entry categorizing these as Level 3 external-service tests
- GHA CI job on a Docker-capable runner running \`just integration-parakeet\`
- Broader uncovered surface: chunked \`process_audio\`, double-\`finalize\`, non-200 / malformed JSON, bearer auth, actual \`main\` bootstrap config discovery
- Shared \`repo_root()\` helper if more live tests land

## Test plan
- [x] \`just integration-parakeet\` green on Windows against docker-compose parakeet-cpu
- [x] Mutation test: \`api_path\` → 404 → plugin test FAIL (reverted)
- [x] Mutation test: \`preferred = mock\` → assertion FAIL before network (reverted)
- [ ] Same on Linux (requires \`.sh\` counterpart — tracked as follow-up)