### PR TITLE
test: scope real injection tests to linux

### DIFF
--- a/crates/coldvox-text-injection/build.rs
+++ b/crates/coldvox-text-injection/build.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
-    // We only need to build the test applications if the `real-injection-tests` feature is enabled.
-    // This avoids adding build-time dependencies for regular users.
-    if env::var("CARGO_FEATURE_REAL_INJECTION_TESTS").is_ok() {
+    // The real injection helper apps are Linux desktop fixtures. Avoid building
+    // them for Windows/macOS when the feature is accidentally enabled.
+    if env::var("CARGO_FEATURE_REAL_INJECTION_TESTS").is_ok()
+        && env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux")
+    {
         build_gtk_test_app();
         build_terminal_test_app();
     }

--- a/crates/coldvox-text-injection/src/tests/mod.rs
+++ b/crates/coldvox-text-injection/src/tests/mod.rs
@@ -1,8 +1,16 @@
 //! Test modules for coldvox-text-injection
 
+#[cfg(all(feature = "real-injection-tests", target_os = "linux"))]
 pub mod real_injection;
-#[cfg(feature = "real-injection-tests")]
+#[cfg(all(feature = "real-injection-tests", target_os = "linux"))]
 pub mod test_harness;
+#[cfg(all(feature = "real-injection-tests", not(target_os = "linux")))]
+mod real_injection {
+    #[test]
+    fn real_injection_tests_are_linux_only() {
+        eprintln!("Skipping real-injection-tests: real desktop injection tests are Linux-only.");
+    }
+}
 pub mod test_utils;
 #[cfg(all(unix, feature = "ydotool"))]
 pub mod test_ydotool_injector;

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,7 +12,7 @@ version: 1.0.0
 # Documentation Todo Backlog
 
 ## Epic: Test OS Scoping (High Priority)
-- [ ] Scope text-injection integration tests to fix `cargo test` failures on Windows. ([plan](./plans/current-status.md))
+- [x] Scope text-injection integration tests to fix `cargo test` failures on Windows. ([plan](./plans/current-status.md))
 
 ## Epic: Documentation Migration
 


### PR DESCRIPTION
## **User description**
## Reading Order
1. `crates/coldvox-text-injection/src/tests/mod.rs` - target gating and non-Linux skip test
2. `crates/coldvox-text-injection/build.rs` - helper app build gating
3. `docs/todo.md` - task system-of-record update

## Summary
- Scope `real-injection-tests` to the Linux desktop harness.
- Add an explicit non-Linux skip test so accidental Windows enablement compiles cleanly instead of partially compiling unused Linux harness code.
- Stop building Linux helper apps for `real-injection-tests` on non-Linux targets.

## Validation
- `cargo fmt --all --check`: passed
- `$env:RUSTFLAGS="-D warnings"; cargo test -p coldvox-text-injection --features real-injection-tests --locked`: passed on Windows, 75 passed / 1 ignored plus doc tests
- `cargo test -p coldvox-text-injection --lib --locked`: passed on Windows, 74 passed / 1 ignored
- `just test`: passed on Windows, including `windows-smoke`; live runtime skipped because `COLDVOX_RUN_WINDOWS_LIVE` was not set

## Review Notes
- This branch is based on `origin/main` per `docs/plans/current-status.md`.
- Current repository branch-gate workflow appears to require PRs into `main` to originate from `tauri-base`; this PR may need integration routing through that branch before merge.

Relates to the text-injection test issue cluster: #325, #326, #306, #308.


___

## **CodeAnt-AI Description**
**Run real injection tests only on Linux and skip them cleanly elsewhere**

### What Changed
- Real desktop injection tests now run only on Linux.
- On Windows and macOS, the test suite shows a clear skip message instead of trying to compile Linux-only test code.
- The Linux helper apps used by these tests are no longer built on non-Linux systems.
- The related tracking item is marked complete.

### Impact
`✅ Fewer Windows test failures`
`✅ Clearer cross-platform test results`
`✅ Less unnecessary build work on non-Linux machines`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Scope Real Injection Tests to Linux

## Overview
This PR restricts the `real-injection-tests` feature to Linux targets only, ensuring clean compilation on Windows while maintaining test functionality on Linux. The changes include platform-aware test gating, conditional helper app builds, and documentation updates.

## Changes

### 🔧 Build Configuration
**File:** `crates/coldvox-text-injection/build.rs`

| Aspect | Details |
|--------|---------|
| **Purpose** | Gate Linux helper app builds to Linux targets only |
| **Change** | Added `target_os = "linux"` check alongside `CARGO_FEATURE_REAL_INJECTION_TESTS` |
| **Impact** | Helper apps for real injection tests now build only when both feature is enabled AND target is Linux |
| **Lines changed** | +5/-3 |

### 🧪 Test Module Gating
**File:** `crates/coldvox-text-injection/src/tests/mod.rs`

| Module | Previous | Current |
|--------|----------|---------|
| `real_injection` | Feature-gated only | Feature + Linux-gated |
| `test_harness` | Feature-gated only | Feature + Linux-gated |
| **Non-Linux fallback** | N/A | Contains skip test with stderr message |

**Changes:**
- Gates both `real_injection` and `test_harness` submodules behind `#[cfg(all(feature = "real-injection-tests", target_os = "linux"))]`
- Defines fallback `real_injection` module for non-Linux targets that contains a test skipping with a message indicating real injection tests are Linux-only
- Other test modules (`test_utils`, `test_ydotool_injector`, `wl_copy_*`) remain unchanged
- **Lines changed:** +9/-1

### 📋 Documentation
**File:** `docs/todo.md`

Marked "Test OS Scoping (High Priority)" checklist item as completed (`[ ]` → `[x]`)
- **Lines changed:** +1/-1

## Validation Results

| Target | Command | Status |
|--------|---------|--------|
| **Windows** | `cargo test -p coldvox-text-injection --features real-injection-tests --locked` | ✅ 75 passed / 1 ignored |
| **Windows** | `cargo test -p coldvox-text-injection --lib --locked` | ✅ 74 passed / 1 ignored |
| **Windows** | `just test` (including `windows-smoke`) | ✅ Passed |
| **All** | `cargo fmt --all --check` | ✅ Passed |

## Related Issues
#325, #326, #306, #308

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Coldaine/ColdVox/pull/428)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->