### PR TITLE
test: harvest TestClock/ringbuf/VAD tests from agent-generated branch (PR-F)

### DIFF
--- a/crates/coldvox-audio/tests/audio_capture_pipeline_tests.rs
+++ b/crates/coldvox-audio/tests/audio_capture_pipeline_tests.rs
@@ -1,0 +1,203 @@
+//! Comprehensive tests for audio capture pipeline components.
+//!
+//! Tests cover: ring buffer, silence detector, watchdog timer, and
+//! audio frame format validation using mocked audio sources.
+
+use coldvox_audio::detector::SilenceDetector;
+use coldvox_audio::AudioRingBuffer;
+
+// ─── Ring Buffer Tests ───────────────────────────────────────────────
+
+#[test]
+fn ring_buffer_write_read_roundtrip() {
+    let buf = AudioRingBuffer::new(4096);
+    let (mut producer, mut consumer) = buf.split();
+
+    let samples: Vec<i16> = (0..512).map(|i| (i % 100) as i16).collect();
+    let written = producer.write(&samples).expect("write should succeed");
+    assert_eq!(written, 512);
+
+    let mut read_buf = vec![0i16; 512];
+    let read_count = consumer.read(&mut read_buf);
+    assert_eq!(read_count, 512);
+    assert_eq!(read_buf, samples);
+}
+
+#[test]
+fn ring_buffer_partial_read() {
+    let buf = AudioRingBuffer::new(4096);
+    let (mut producer, mut consumer) = buf.split();
+
+    let samples: Vec<i16> = (0..256).map(|i| i as i16).collect();
+    producer.write(&samples).unwrap();
+
+    let mut first_half = vec![0i16; 128];
+    assert_eq!(consumer.read(&mut first_half), 128);
+    assert_eq!(first_half, samples[..128]);
+
+    let mut second_half = vec![0i16; 128];
+    assert_eq!(consumer.read(&mut second_half), 128);
+    assert_eq!(second_half, samples[128..256]);
+}
+
+#[test]
+fn ring_buffer_read_empty_returns_zero() {
+    let buf = AudioRingBuffer::new(1024);
+    let (_producer, mut consumer) = buf.split();
+
+    let mut read_buf = vec![0i16; 512];
+    assert_eq!(consumer.read(&mut read_buf), 0);
+}
+
+#[test]
+fn ring_buffer_overflow_returns_error() {
+    let buf = AudioRingBuffer::new(64);
+    let (mut producer, _consumer) = buf.split();
+
+    let samples = vec![1i16; 128];
+    assert!(producer.write(&samples).is_err());
+}
+
+#[test]
+fn ring_buffer_wrap_around_preserves_data() {
+    let buf = AudioRingBuffer::new(256);
+    let (mut producer, mut consumer) = buf.split();
+
+    // Fill and partially drain to force wrap-around
+    let fill = vec![1i16; 200];
+    producer.write(&fill).unwrap();
+    let mut drain = vec![0i16; 180];
+    consumer.read(&mut drain);
+
+    let wrap_data: Vec<i16> = (10..110).collect();
+    producer.write(&wrap_data).unwrap();
+
+    // Drain original remainder
+    let mut remainder = vec![0i16; 20];
+    consumer.read(&mut remainder);
+
+    // Read wrapped data
+    let mut wrapped = vec![0i16; 100];
+    assert_eq!(consumer.read(&mut wrapped), 100);
+    assert_eq!(wrapped, wrap_data);
+}
+
+#[test]
+fn ring_buffer_slots_decrease_after_write() {
+    let buf = AudioRingBuffer::new(1024);
+    let (mut producer, _consumer) = buf.split();
+
+    let initial = producer.slots();
+    producer.write(&vec![0i16; 100]).unwrap();
+    assert_eq!(producer.slots(), initial - 100);
+}
+
+#[test]
+fn ring_buffer_preserves_extreme_sample_values() {
+    let buf = AudioRingBuffer::new(4096);
+    let (mut producer, mut consumer) = buf.split();
+
+    let samples = vec![i16::MIN, -1000, -1, 0, 1, 1000, i16::MAX];
+    producer.write(&samples).unwrap();
+
+    let mut read_buf = vec![0i16; 7];
+    consumer.read(&mut read_buf);
+    assert_eq!(read_buf, samples);
+}
+
+#[test]
+fn ring_buffer_16khz_vad_frame_size() {
+    // VAD expects 512 samples at 16kHz (32ms frames)
+    let buf = AudioRingBuffer::new(16384);
+    let (mut producer, mut consumer) = buf.split();
+
+    for _ in 0..10 {
+        let frame = vec![0i16; 512];
+        producer.write(&frame).unwrap();
+    }
+
+    let mut read_buf = vec![0i16; 5120];
+    assert_eq!(consumer.read(&mut read_buf), 5120);
+}
+
+// ─── Silence Detector Tests ─────────────────────────────────────────
+
+#[test]
+fn silence_detector_detects_pure_silence() {
+    let mut det = SilenceDetector::new(100);
+    let silence = vec![0i16; 512];
+    assert!(det.is_silence(&silence));
+}
+
+#[test]
+fn silence_detector_detects_loud_audio_as_not_silence() {
+    let mut det = SilenceDetector::new(100);
+    let loud: Vec<i16> = vec![10000; 512];
+    assert!(!det.is_silence(&loud));
+}
+
+#[test]
+fn silence_detector_threshold_boundary() {
+    let threshold = 500;
+    let mut det = SilenceDetector::new(threshold);
+
+    // Just below threshold — silence
+    let quiet: Vec<i16> = vec![400; 512];
+    assert!(det.is_silence(&quiet));
+
+    // Above threshold — not silence
+    let medium: Vec<i16> = vec![2000; 512];
+    assert!(!det.is_silence(&medium));
+}
+
+#[test]
+fn silence_detector_transitions_speech_to_silence() {
+    let mut det = SilenceDetector::new(100);
+
+    // Speech
+    let speech = vec![5000i16; 512];
+    assert!(!det.is_silence(&speech));
+    assert_eq!(det.silence_duration().as_millis(), 0);
+
+    // Transition to silence
+    let silence = vec![0i16; 512];
+    assert!(det.is_silence(&silence));
+    // Duration should be >= 0 after registering silence start
+    assert!(det.silence_duration().as_millis() >= 0);
+}
+
+#[test]
+fn silence_detector_reset_clears_state() {
+    let mut det = SilenceDetector::new(100);
+
+    let silence = vec![0i16; 512];
+    det.is_silence(&silence);
+    det.reset();
+
+    // After reset, silence_duration should be zero
+    assert_eq!(det.silence_duration().as_millis(), 0);
+}
+
+#[test]
+fn silence_detector_sine_wave_detection() {
+    let mut det = SilenceDetector::new(100);
+
+    // Generate a 440Hz sine wave at reasonable volume
+    let sine: Vec<i16> = (0..512)
+        .map(|i| {
+            let phase = 2.0 * std::f64::consts::PI * 440.0 * i as f64 / 16000.0;
+            (phase.sin() * 8000.0) as i16
+        })
+        .collect();
+
+    assert!(!det.is_silence(&sine), "sine wave should not be detected as silence");
+}
+
+#[test]
+fn silence_detector_low_noise_floor() {
+    let mut det = SilenceDetector::new(50);
+
+    // Very quiet noise (simulating mic self-noise)
+    let noise: Vec<i16> = (0..512).map(|i| ((i % 7) as i16 - 3)).collect();
+    assert!(det.is_silence(&noise), "low-level noise should be detected as silence");
+}

--- a/crates/coldvox-foundation/tests/foundation_tests.rs
+++ b/crates/coldvox-foundation/tests/foundation_tests.rs
@@ -1,0 +1,211 @@
+//! Foundation crate tests
+//!
+//! Tests cover:
+//! - Clock abstraction (RealClock, TestClock, SharedClock)
+//! - Error types (ColdVoxError variants, AudioError, SttError, VadError, InjectionError)
+//! - Test environment utilities
+
+use coldvox_foundation::clock::{Clock, RealClock, TestClock, real_clock, test_clock};
+use coldvox_foundation::error::{
+    AudioError, ColdVoxError, ConfigError, InjectionError, PluginError, SttError, VadError,
+};
+use std::time::{Duration, Instant};
+
+// ─── RealClock Tests ────────────────────────────────────────────────
+
+#[test]
+fn real_clock_now_returns_current_time() {
+    let clock = RealClock::new();
+    let before = Instant::now();
+    let clock_time = clock.now();
+    let after = Instant::now();
+    assert!(clock_time >= before);
+    assert!(clock_time <= after);
+}
+
+#[test]
+fn real_clock_factory_function() {
+    let clock = real_clock();
+    let t = clock.now();
+    assert!(t.elapsed() < Duration::from_secs(1));
+}
+
+// ─── TestClock Tests ────────────────────────────────────────────────
+
+#[test]
+fn test_clock_starts_at_current_time() {
+    let before = Instant::now();
+    let clock = TestClock::new();
+    let clock_time = clock.now();
+    // TestClock initialized with Instant::now(), should be very close
+    assert!(clock_time.duration_since(before) < Duration::from_millis(100));
+}
+
+#[test]
+fn test_clock_advance() {
+    let clock = TestClock::new();
+    let t0 = clock.now();
+    clock.advance(Duration::from_secs(5));
+    let t1 = clock.now();
+    assert_eq!(t1.duration_since(t0), Duration::from_secs(5));
+}
+
+#[test]
+fn test_clock_advance_accumulates() {
+    let clock = TestClock::new();
+    let start = clock.now();
+    clock.advance(Duration::from_millis(100));
+    clock.advance(Duration::from_millis(200));
+    clock.advance(Duration::from_millis(300));
+    let elapsed = clock.now().duration_since(start);
+    assert_eq!(elapsed, Duration::from_millis(600));
+}
+
+#[test]
+fn test_clock_sleep_advances_time() {
+    let clock = TestClock::new();
+    let t0 = clock.now();
+    clock.sleep(Duration::from_secs(10));
+    let t1 = clock.now();
+    assert_eq!(t1.duration_since(t0), Duration::from_secs(10));
+}
+
+#[test]
+fn test_clock_set_time() {
+    let clock = TestClock::new();
+    let target = Instant::now() + Duration::from_secs(1000);
+    clock.set_time(target);
+    assert_eq!(clock.now(), target);
+}
+
+#[test]
+fn test_clock_factory_function() {
+    let clock = test_clock();
+    let t = clock.now();
+    clock.sleep(Duration::from_secs(1));
+    let t2 = clock.now();
+    assert_eq!(t2.duration_since(t), Duration::from_secs(1));
+}
+
+// ─── Error Type Tests ───────────────────────────────────────────────
+
+#[test]
+fn audio_error_device_not_found() {
+    let err = AudioError::DeviceNotFound { name: Some("test_mic".to_string()) };
+    let msg = format!("{}", err);
+    assert!(msg.contains("test_mic"));
+}
+
+#[test]
+fn audio_error_buffer_overflow() {
+    let err = AudioError::BufferOverflow { count: 512 };
+    let msg = format!("{}", err);
+    assert!(msg.contains("512"));
+}
+
+#[test]
+fn audio_error_format_not_supported() {
+    let err = AudioError::FormatNotSupported { format: "f64".to_string() };
+    let msg = format!("{}", err);
+    assert!(msg.contains("f64"));
+}
+
+#[test]
+fn stt_error_transcription_failed() {
+    let err = SttError::TranscriptionFailed("timeout".to_string());
+    let msg = format!("{}", err);
+    assert!(msg.contains("timeout"));
+}
+
+#[test]
+fn stt_error_model_not_found() {
+    let err = SttError::ModelNotFound { path: "/models/whisper".into() };
+    let msg = format!("{}", err);
+    assert!(msg.contains("whisper"));
+}
+
+#[test]
+fn vad_error_invalid_frame_size() {
+    let err = VadError::InvalidFrameSize { expected: 512, actual: 256 };
+    let msg = format!("{}", err);
+    assert!(msg.contains("512"));
+    assert!(msg.contains("256"));
+}
+
+#[test]
+fn injection_error_timeout() {
+    let err = InjectionError::Timeout(5000);
+    let msg = format!("{}", err);
+    assert!(msg.contains("5000"));
+}
+
+#[test]
+fn injection_error_no_editable_focus() {
+    let err = InjectionError::NoEditableFocus;
+    let msg = format!("{}", err);
+    assert!(msg.contains("editable focus"));
+}
+
+#[test]
+fn coldvox_error_from_audio_error() {
+    let audio_err = AudioError::DeviceDisconnected;
+    let err: ColdVoxError = audio_err.into();
+    assert!(matches!(err, ColdVoxError::Audio(_)));
+}
+
+#[test]
+fn coldvox_error_from_stt_error() {
+    let stt_err = SttError::TranscriptionFailed("test".to_string());
+    let err: ColdVoxError = stt_err.into();
+    assert!(matches!(err, ColdVoxError::Stt(_)));
+}
+
+#[test]
+fn coldvox_error_from_vad_error() {
+    let vad_err = VadError::ProcessingFailed("test".to_string());
+    let err: ColdVoxError = vad_err.into();
+    assert!(matches!(err, ColdVoxError::Vad(_)));
+}
+
+#[test]
+fn coldvox_error_from_injection_error() {
+    let inj_err = InjectionError::NoEditableFocus;
+    let err: ColdVoxError = inj_err.into();
+    assert!(matches!(err, ColdVoxError::Injection(_)));
+}
+
+#[test]
+fn coldvox_error_shutdown() {
+    let err = ColdVoxError::ShutdownRequested;
+    let msg = format!("{}", err);
+    assert!(msg.contains("Shutdown"));
+}
+
+#[test]
+fn coldvox_error_fatal() {
+    let err = ColdVoxError::Fatal("critical failure".to_string());
+    let msg = format!("{}", err);
+    assert!(msg.contains("critical failure"));
+}
+
+#[test]
+fn config_error_validation() {
+    let err = ConfigError::Validation {
+        field: "sample_rate".to_string(),
+        reason: "must be 16000".to_string(),
+    };
+    let msg = format!("{}", err);
+    assert!(msg.contains("sample_rate"));
+}
+
+#[test]
+fn plugin_error_lifecycle() {
+    let err = PluginError::Lifecycle {
+        plugin: "moonshine".to_string(),
+        operation: "initialize".to_string(),
+        reason: "Python not found".to_string(),
+    };
+    let msg = format!("{}", err);
+    assert!(msg.contains("moonshine"));
+    assert!(msg.contains("initialize"));
+}

--- a/crates/coldvox-vad/tests/vad_comprehensive_tests.rs
+++ b/crates/coldvox-vad/tests/vad_comprehensive_tests.rs
@@ -1,0 +1,417 @@
+//! Comprehensive VAD (Voice Activity Detection) tests
+//!
+//! Tests cover:
+//! - Energy calculation (RMS, dBFS)
+//! - Adaptive threshold (noise floor tracking, onset/offset)
+//! - State machine (silence→speech→silence transitions, debouncing)
+//! - VadConfig validation
+//! - Speech boundary detection accuracy
+
+use coldvox_vad::types::{VadConfig, VadEvent, VadState};
+use coldvox_vad::constants::{FRAME_SIZE_SAMPLES, SAMPLE_RATE_HZ, FRAME_DURATION_MS};
+use coldvox_vad::energy::EnergyCalculator;
+use coldvox_vad::state::VadStateMachine;
+use coldvox_vad::threshold::AdaptiveThreshold;
+
+// ─── Energy Calculator Tests ─────────────────────────────────────────
+
+#[test]
+fn energy_silence_is_very_low_dbfs() {
+    let calc = EnergyCalculator::new();
+    let silence = vec![0i16; FRAME_SIZE_SAMPLES];
+    let db = calc.calculate_dbfs(&silence);
+    assert!(db <= -100.0, "silence should be <= -100 dBFS, got {}", db);
+}
+
+#[test]
+fn energy_full_scale_near_zero_dbfs() {
+    let calc = EnergyCalculator::new();
+    let full = vec![i16::MAX; FRAME_SIZE_SAMPLES];
+    let db = calc.calculate_dbfs(&full);
+    assert!((db - 0.0).abs() < 0.1, "full scale should be ~0 dBFS, got {}", db);
+}
+
+#[test]
+fn energy_rms_sine_wave() {
+    let calc = EnergyCalculator::new();
+    let sine: Vec<i16> = (0..FRAME_SIZE_SAMPLES)
+        .map(|i| {
+            let phase = 2.0 * std::f32::consts::PI * i as f32 / FRAME_SIZE_SAMPLES as f32;
+            (phase.sin() * 16384.0) as i16
+        })
+        .collect();
+
+    let rms = calc.calculate_rms(&sine);
+    // Sine wave RMS = peak / sqrt(2) ≈ 0.707 * peak
+    // 16384 / 32768 = 0.5, RMS ≈ 0.5 / sqrt(2) ≈ 0.354
+    assert!((rms - 0.354).abs() < 0.02, "sine wave RMS should be ~0.354, got {}", rms);
+}
+
+#[test]
+fn energy_rms_empty_frame_returns_zero() {
+    let calc = EnergyCalculator::new();
+    let empty: Vec<i16> = vec![];
+    assert_eq!(calc.calculate_rms(&empty), 0.0);
+}
+
+#[test]
+fn energy_dbfs_monotonically_increases_with_amplitude() {
+    let calc = EnergyCalculator::new();
+    let mut prev_db = f32::NEG_INFINITY;
+
+    for amplitude in [100, 500, 1000, 5000, 10000, 20000, 30000] {
+        let frame = vec![amplitude as i16; FRAME_SIZE_SAMPLES];
+        let db = calc.calculate_dbfs(&frame);
+        assert!(db > prev_db, "dBFS should increase with amplitude: {} dB at amplitude {}", db, amplitude);
+        prev_db = db;
+    }
+}
+
+#[test]
+fn energy_ratio_positive_when_above_reference() {
+    let calc = EnergyCalculator::new();
+    let loud = vec![10000i16; FRAME_SIZE_SAMPLES];
+    let ratio = calc.calculate_energy_ratio(&loud, -50.0);
+    assert!(ratio > 0.0, "energy ratio should be positive above reference");
+}
+
+#[test]
+fn energy_ratio_negative_when_below_reference() {
+    let calc = EnergyCalculator::new();
+    let quiet = vec![10i16; FRAME_SIZE_SAMPLES];
+    let ratio = calc.calculate_energy_ratio(&quiet, -10.0);
+    assert!(ratio < 0.0, "energy ratio should be negative below reference");
+}
+
+// ─── Adaptive Threshold Tests ────────────────────────────────────────
+
+#[test]
+fn threshold_initialization_from_config() {
+    let config = VadConfig::default();
+    let threshold = AdaptiveThreshold::new(&config);
+
+    assert_eq!(threshold.current_floor(), -50.0);
+    assert_eq!(threshold.onset_threshold(), -50.0 + 9.0);  // -41.0
+    assert_eq!(threshold.offset_threshold(), -50.0 + 6.0); // -44.0
+}
+
+#[test]
+fn threshold_adapts_noise_floor_during_silence() {
+    let config = VadConfig {
+        ema_alpha: 0.1,
+        ..Default::default()
+    };
+    let mut t = AdaptiveThreshold::new(&config);
+
+    t.update(-40.0, false);
+    let floor_after_one = t.current_floor();
+    // EMA: (1 - 0.1) * (-50) + 0.1 * (-40) = -45 + -4 = -49
+    assert!((floor_after_one - (-49.0)).abs() < 0.01);
+}
+
+#[test]
+fn threshold_does_not_adapt_during_speech() {
+    let config = VadConfig::default();
+    let mut t = AdaptiveThreshold::new(&config);
+
+    let initial = t.current_floor();
+    t.update(-30.0, true);
+    t.update(-25.0, true);
+    assert_eq!(t.current_floor(), initial);
+}
+
+#[test]
+fn threshold_activation_detection() {
+    let config = VadConfig::default();
+    let t = AdaptiveThreshold::new(&config);
+
+    // onset_threshold = -50 + 9 = -41
+    assert!(t.should_activate(-40.0));   // above onset
+    assert!(!t.should_activate(-42.0));  // below onset
+}
+
+#[test]
+fn threshold_deactivation_detection() {
+    let config = VadConfig::default();
+    let t = AdaptiveThreshold::new(&config);
+
+    // offset_threshold = -50 + 6 = -44
+    assert!(t.should_deactivate(-45.0));  // below offset
+    assert!(!t.should_deactivate(-43.0)); // above offset
+}
+
+#[test]
+fn threshold_reset_restores_initial_floor() {
+    let config = VadConfig {
+        ema_alpha: 0.5,
+        initial_floor_db: -50.0,
+        ..Default::default()
+    };
+    let mut t = AdaptiveThreshold::new(&config);
+
+    // Modify floor
+    t.update(-30.0, false);
+    assert_ne!(t.current_floor(), -50.0);
+
+    // Reset
+    t.reset(-50.0);
+    assert_eq!(t.current_floor(), -50.0);
+}
+
+#[test]
+fn threshold_floor_clamped_to_valid_range() {
+    let config = VadConfig::default();
+    let mut t = AdaptiveThreshold::new(&config);
+
+    // Try extremely low value
+    t.reset(-200.0);
+    assert!(t.current_floor() >= -80.0, "floor should be clamped to min");
+
+    // Try extremely high value
+    t.reset(0.0);
+    assert!(t.current_floor() <= -20.0, "floor should be clamped to max");
+}
+
+// ─── State Machine Tests ─────────────────────────────────────────────
+
+#[test]
+fn state_machine_starts_in_silence() {
+    let config = VadConfig::default();
+    let sm = VadStateMachine::new(&config);
+    assert_eq!(sm.current_state(), VadState::Silence);
+}
+
+#[test]
+fn state_machine_transitions_to_speech_after_debounce() {
+    let config = VadConfig {
+        speech_debounce_ms: 64,  // 2 frames at 32ms each
+        ..Default::default()
+    };
+    let mut sm = VadStateMachine::new(&config);
+
+    // First speech frame — still in debounce
+    let event1 = sm.process(true, -30.0);
+    assert!(event1.is_none());
+    assert_eq!(sm.current_state(), VadState::Silence);
+
+    // Second speech frame — debounce met, should transition
+    let event2 = sm.process(true, -30.0);
+    assert!(event2.is_some());
+    if let Some(VadEvent::SpeechStart { energy_db, .. }) = event2 {
+        assert!((energy_db - (-30.0)).abs() < 0.01);
+    } else {
+        panic!("Expected SpeechStart event");
+    }
+    assert_eq!(sm.current_state(), VadState::Speech);
+}
+
+#[test]
+fn state_machine_transitions_to_silence_after_debounce() {
+    let config = VadConfig {
+        speech_debounce_ms: 32,   // 1 frame
+        silence_debounce_ms: 64,  // 2 frames
+        ..Default::default()
+    };
+    let mut sm = VadStateMachine::new(&config);
+
+    // Enter speech state
+    sm.process(true, -30.0);
+
+    // First silence frame — still debouncing
+    let ev1 = sm.process(false, -50.0);
+    assert!(ev1.is_none());
+    assert_eq!(sm.current_state(), VadState::Speech);
+
+    // Second silence frame — debounce met
+    let ev2 = sm.process(false, -50.0);
+    assert!(ev2.is_some());
+    if let Some(VadEvent::SpeechEnd { duration_ms, .. }) = ev2 {
+        assert!(duration_ms > 0, "speech duration should be > 0");
+    } else {
+        panic!("Expected SpeechEnd event");
+    }
+    assert_eq!(sm.current_state(), VadState::Silence);
+}
+
+#[test]
+fn state_machine_speech_interrupted_by_brief_silence() {
+    let config = VadConfig {
+        speech_debounce_ms: 32,   // 1 frame
+        silence_debounce_ms: 96,  // 3 frames
+        ..Default::default()
+    };
+    let mut sm = VadStateMachine::new(&config);
+
+    // Enter speech
+    sm.process(true, -30.0);
+    assert_eq!(sm.current_state(), VadState::Speech);
+
+    // Brief silence (1 frame) — doesn't meet debounce
+    sm.process(false, -50.0);
+    assert_eq!(sm.current_state(), VadState::Speech);
+
+    // Back to speech — resets silence counter
+    sm.process(true, -30.0);
+    assert_eq!(sm.current_state(), VadState::Speech);
+}
+
+#[test]
+fn state_machine_reset() {
+    let config = VadConfig {
+        speech_debounce_ms: 32,
+        ..Default::default()
+    };
+    let mut sm = VadStateMachine::new(&config);
+
+    // Enter speech
+    sm.process(true, -30.0);
+    assert_eq!(sm.current_state(), VadState::Speech);
+
+    // Reset
+    sm.reset();
+    assert_eq!(sm.current_state(), VadState::Silence);
+}
+
+#[test]
+fn state_machine_multiple_speech_segments() {
+    let config = VadConfig {
+        speech_debounce_ms: 32,
+        silence_debounce_ms: 32,
+        ..Default::default()
+    };
+    let mut sm = VadStateMachine::new(&config);
+
+    let mut speech_starts = 0;
+    let mut speech_ends = 0;
+
+    // Simulate 3 speech segments with silence gaps
+    for _segment in 0..3 {
+        // Speech on
+        for _ in 0..5 {
+            if let Some(VadEvent::SpeechStart { .. }) = sm.process(true, -30.0) {
+                speech_starts += 1;
+            }
+        }
+        // Silence gap
+        for _ in 0..5 {
+            if let Some(VadEvent::SpeechEnd { .. }) = sm.process(false, -60.0) {
+                speech_ends += 1;
+            }
+        }
+    }
+
+    assert_eq!(speech_starts, 3, "should have 3 speech starts");
+    assert_eq!(speech_ends, 3, "should have 3 speech ends");
+}
+
+// ─── VadConfig Tests ─────────────────────────────────────────────────
+
+#[test]
+fn vad_config_default_values() {
+    let config = VadConfig::default();
+    assert_eq!(config.onset_threshold_db, 9.0);
+    assert_eq!(config.offset_threshold_db, 6.0);
+    assert_eq!(config.ema_alpha, 0.02);
+    assert_eq!(config.speech_debounce_ms, 200);
+    assert_eq!(config.silence_debounce_ms, 400);
+    assert_eq!(config.initial_floor_db, -50.0);
+    assert_eq!(config.frame_size_samples, FRAME_SIZE_SAMPLES);
+    assert_eq!(config.sample_rate_hz, SAMPLE_RATE_HZ);
+}
+
+#[test]
+fn vad_config_frame_duration_calculation() {
+    let config = VadConfig::default();
+    // 512 samples / 16000 Hz * 1000 = 32ms
+    assert!((config.frame_duration_ms() - 32.0).abs() < 0.01);
+}
+
+#[test]
+fn vad_config_debounce_frame_counts() {
+    let config = VadConfig {
+        speech_debounce_ms: 200,
+        silence_debounce_ms: 400,
+        frame_size_samples: 512,
+        sample_rate_hz: 16000,
+        ..Default::default()
+    };
+
+    // 200ms / 32ms = 6.25 → ceil = 7
+    assert_eq!(config.speech_debounce_frames(), 7);
+    // 400ms / 32ms = 12.5 → ceil = 13
+    assert_eq!(config.silence_debounce_frames(), 13);
+}
+
+// ─── Constants Tests ─────────────────────────────────────────────────
+
+#[test]
+fn vad_constants_standard_values() {
+    assert_eq!(SAMPLE_RATE_HZ, 16_000);
+    assert_eq!(FRAME_SIZE_SAMPLES, 512);
+    // 512 / 16000 * 1000 = 32.0
+    assert!((FRAME_DURATION_MS - 32.0).abs() < 0.01);
+}
+
+// ─── Integration: Simulated Audio Pipeline ───────────────────────────
+
+#[test]
+fn vad_detects_speech_in_simulated_audio_stream() {
+    let config = VadConfig {
+        speech_debounce_ms: 32,   // 1 frame
+        silence_debounce_ms: 64,  // 2 frames
+        onset_threshold_db: 9.0,
+        offset_threshold_db: 6.0,
+        initial_floor_db: -50.0,
+        ..Default::default()
+    };
+    let calc = EnergyCalculator::new();
+    let mut threshold = AdaptiveThreshold::new(&config);
+    let mut sm = VadStateMachine::new(&config);
+
+    let mut events: Vec<VadEvent> = Vec::new();
+
+    // Simulate: 5 silence frames → 10 speech frames → 5 silence frames
+    let silence_frame = vec![0i16; FRAME_SIZE_SAMPLES];
+    let speech_frame: Vec<i16> = (0..FRAME_SIZE_SAMPLES)
+        .map(|i| {
+            let phase = 2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0;
+            (phase.sin() * 10000.0) as i16
+        })
+        .collect();
+
+    // Silence warmup
+    for _ in 0..5 {
+        let db = calc.calculate_dbfs(&silence_frame);
+        let is_speech = threshold.should_activate(db);
+        threshold.update(db, is_speech);
+        if let Some(ev) = sm.process(is_speech, db) {
+            events.push(ev);
+        }
+    }
+
+    // Speech
+    for _ in 0..10 {
+        let db = calc.calculate_dbfs(&speech_frame);
+        let is_speech = threshold.should_activate(db);
+        threshold.update(db, is_speech);
+        if let Some(ev) = sm.process(is_speech, db) {
+            events.push(ev);
+        }
+    }
+
+    // Silence tail
+    for _ in 0..5 {
+        let db = calc.calculate_dbfs(&silence_frame);
+        let is_speech = threshold.should_deactivate(db);
+        // Note: during speech state, we check deactivation
+        let below_offset = threshold.should_deactivate(db);
+        threshold.update(db, !below_offset);
+        if let Some(ev) = sm.process(!below_offset, db) {
+            events.push(ev);
+        }
+    }
+
+    // Should have detected at least one SpeechStart
+    let starts: Vec<_> = events.iter().filter(|e| matches!(e, VadEvent::SpeechStart { .. })).collect();
+    assert!(!starts.is_empty(), "should detect speech start; events: {:?}", events);
+}

--- a/crates/coldvox-vad/tests/vad_comprehensive_tests.rs
+++ b/crates/coldvox-vad/tests/vad_comprehensive_tests.rs
@@ -402,11 +402,12 @@ fn vad_detects_speech_in_simulated_audio_stream() {
     // Silence tail
     for _ in 0..5 {
         let db = calc.calculate_dbfs(&silence_frame);
-        let is_speech = threshold.should_deactivate(db);
-        // Note: during speech state, we check deactivation
+        // should_deactivate returns true when energy is below the offset threshold (i.e., silence).
+        // is_speech_candidate = false when below_offset = true (silence detected).
         let below_offset = threshold.should_deactivate(db);
-        threshold.update(db, !below_offset);
-        if let Some(ev) = sm.process(!below_offset, db) {
+        let is_speech_candidate = !below_offset;
+        threshold.update(db, is_speech_candidate);
+        if let Some(ev) = sm.process(is_speech_candidate, db) {
             events.push(ev);
         }
     }


### PR DESCRIPTION
## Summary

- Cherry-picks 3 real test files from `origin/agent/coldvox/test-foundation` onto `rescue-pr-a` (stacked below `tauri-base`)
- Drops 2 slop-heavy commits (STT mocks, NoOp text-injection) per code-reviewer audit
- Removes duplicate/flaky `watchdog_tests.rs` from `coldvox-audio`
- Fixes a logic clarity bug in the VAD silence-tail test loop

## Stack Note

This PR (`rescue/test-foundation-harvest`) is based on **`rescue-pr-a`**, which is itself based on `tauri-base`. Merge order: `tauri-base` → `rescue-pr-a` → this PR.

## Cherry-Picked Commits

| SHA | Description |
|-----|-------------|
| `41c8d3f` | `crates/coldvox-foundation/tests/foundation_tests.rs` — TestClock contract tests |
| `660d466` | `crates/coldvox-audio/tests/audio_capture_pipeline_tests.rs` — ring-buffer/pipeline tests (watchdog_tests.rs removed, see below) |
| `a671126` | `crates/coldvox-vad/tests/vad_comprehensive_tests.rs` — energy/threshold/state-machine tests |

## Dropped Commits (Slop)

| SHA | Reason |
|-----|--------|
| `631df65` | STT comprehensive tests — predominantly mock-testing internal implementation details with no real contract coverage |
| `508e6aa` | Text-injection tests — mostly NoOp tautologies that test the absence of side effects rather than real behavior |

## watchdog_tests.rs Removal

`crates/coldvox-audio/tests/watchdog_tests.rs` was cherry-picked as part of `660d466` but removed before amending the commit. Reasons:

1. **Duplicate**: `crates/app/tests/unit/watchdog_test.rs` on `main` already covers watchdog behaviour
2. **Flaky**: the original file used `thread::sleep` timing assumptions prone to CI races
3. **No other refs**: no `[[test]]` entries in `coldvox-audio/Cargo.toml`, no `mod` declarations referencing it

## VAD Logic Bug Fix

**Commit**: `ed426e6` — `fix(vad-tests): correct silence-tail signal in vad_detects_speech_in_simulated_audio_stream`

The silence-tail loop in `vad_detects_speech_in_simulated_audio_stream` had a dead variable (`is_speech`) and called `should_deactivate()` twice. The variable name was misleading about boolean polarity. `should_deactivate()` returns `true` when energy is **below** the offset threshold (i.e., silence detected), so the `is_speech_candidate` passed to `sm.process()` must be `!below_offset`.

**Before:**
```rust
// Silence tail
for _ in 0..5 {
    let db = calc.calculate_dbfs(&silence_frame);
    let is_speech = threshold.should_deactivate(db);   // dead variable
    // Note: during speech state, we check deactivation
    let below_offset = threshold.should_deactivate(db); // called twice
    threshold.update(db, !below_offset);
    if let Some(ev) = sm.process(!below_offset, db) {
        events.push(ev);
    }
}
```

**After:**
```rust
// Silence tail
for _ in 0..5 {
    let db = calc.calculate_dbfs(&silence_frame);
    // should_deactivate returns true when energy is below the offset threshold (i.e., silence).
    // is_speech_candidate = false when below_offset = true (silence detected).
    let below_offset = threshold.should_deactivate(db);
    let is_speech_candidate = !below_offset;
    threshold.update(db, is_speech_candidate);
    if let Some(ev) = sm.process(is_speech_candidate, db) {
        events.push(ev);
    }
}
```

## Per-Crate Test Pass Count

| Crate | Tests Passed | Ignored |
|-------|-------------|---------|
| `coldvox-foundation` | 56 | 2 |
| `coldvox-audio` | 60 | 0 |
| `coldvox-vad` | 36 | 0 |
| **Total** | **152** | **2** |

All harvested tests pass on Windows with `--locked`.